### PR TITLE
Proposed version bump to 1.1.5 - power plug switch update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 Makes Homey work with these nice and cheap chinese z-wave products
 
 ## Supported devices with most common parameters:
-* NAS-AB01ZE, Siren
-* NAS-DS01ZE, Door Sensor
 * NAS-PD01ZE, Motion Sensor
 * NAS-WR01ZE, Power Switching Plug
+
+## Supported devices with some parameters:
+* NAS-AB01ZE, Siren
+* NAS-DS01ZE, Door Sensor
 * NAS-WS01ZE, Flood Sensor
 
 ## Todo

--- a/README.md
+++ b/README.md
@@ -1,19 +1,14 @@
 # SZ Neo Coolcam device support App for Homey @ Athom.com
-
 Makes Homey work with these nice and cheap chinese z-wave products
 
--	NAS-AB01ZE		Siren
-
--	NAS-DS01ZE		Door Sensor
-
--	NAS-PD01ZE		Motion Sensor
-
--	NAS-WR01ZE		Power Switching Plug
-
--	NAS-WS01ZE		Flood Sensor
+## Supported devices with most common parameters:
+* NAS-AB01ZE, Siren
+* NAS-DS01ZE, Door Sensor
+* NAS-PD01ZE, Motion Sensor
+* NAS-WR01ZE, Power Switching Plug
+* NAS-WS01ZE, Flood Sensor
 
 ## Todo
-
 Some users report no Lux from Motion Sensor. 
 If you can, please sens in a debug of the PIR sending its data.
 All my PIRs are reporting in Lux so hard to troubleshoot

--- a/README.md
+++ b/README.md
@@ -17,8 +17,5 @@ All my PIRs are reporting in Lux so hard to troubleshoot
 ### v 1.1.5
 **add support:**  
 NAS-WR01ZE - Additional settings implemented (e.g. over-load current, alarm current, time switch function)
-
 **update:**  
-NAS-WR01ZE - Bug fixes defaultConfiguration and parameters
-NAS-WR01ZE - Implementation of power consumption (kWh)
-NAS-WR01ZE - Textual fixes (setting-labels, -hints and association group-hints)
+NAS-WR01ZE - Bug fixes defaultConfiguration and parameters, implementation of power consumption (kWh), textual fixes (setting-labels, -hints and association group-hints)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ All my PIRs are reporting in Lux so hard to troubleshoot
 ### v 1.1.5
 **add support:**  
 NAS-WR01ZE - Additional settings implemented (e.g. over-load current, alarm current, time switch function)
+
 **update:**  
 NAS-WR01ZE - Bug fixes defaultConfiguration and parameters
 NAS-WR01ZE - Implementation of power consumption (kWh)

--- a/README.md
+++ b/README.md
@@ -12,15 +12,17 @@ Makes Homey work with these nice and cheap chinese z-wave products
 
 -	NAS-WS01ZE		Flood Sensor
 
-
-
-Please take note: The power usage on the powerplug has been fixed. 
-In order to get it working like it should you have to re-pair your plug again, sorry...... :(
-
-
-Todo
-
+## Todo
 
 Some users report no Lux from Motion Sensor. 
 If you can, please sens in a debug of the PIR sending its data.
 All my PIRs are reporting in Lux so hard to troubleshoot
+
+## Change Log:
+### v 1.1.5
+**add support:**  
+NAS-WR01ZE - Additional settings implemented (e.g. over-load current, alarm current, time switch function)
+**update:**  
+NAS-WR01ZE - Bug fixes defaultConfiguration and parameters
+NAS-WR01ZE - Implementation of power consumption (kWh)
+NAS-WR01ZE - Textual fixes (setting-labels, -hints and association group-hints)

--- a/app.json
+++ b/app.json
@@ -71,7 +71,7 @@
 					{
 						"id": 1,
 						"size": 1,
-						"value": 120
+						"value": 1
 					},
 					{
 						"id": 2,
@@ -91,7 +91,7 @@
 					{
 						"id": 7,
 						"size": 1,
-						"value": true
+						"value": "0xFF"
 					}	
 				]
 			},
@@ -110,13 +110,13 @@
 				    "id": "meter_report",
 				    "type": "checkbox",
 				    "label": {
-					    "en": "1. Meter Report",
-						"nl": "1. Meter Report"
+					    "en": "Enable Meter Report",
+						"nl": "Meter Reportage inschakelen"
 				    },
 				    "value": true,
 				    "hint": {
-					    "en": "This will Disable/Enable meter report measure data to controller. (default: enabled = checked)",
-						"nl": "Dit zal meter rapportages inschakelen naar controller. (standaard: ingeschakeld = checked)"
+					    "en": "#1. This will Disable/Enable meter report measure data to controller. (default: enabled = checked)",
+						"nl": "#1. Dit zal meter rapportages inschakelen naar controller. (standaard: ingeschakeld = checked)"
 				    }
 			    	},
 				{
@@ -128,12 +128,12 @@
 					},
 					"value": 120,
 					"label": {
-						"en": "2. Meter Report Interval [s]",
-						"nl": "2. Meter Report Interval [s]"
+						"en": "Meter Report Interval [s]",
+						"nl": "Meter Reportage Interval [s]"
 					},
 					"hint": {
-						"en": "The amount of seconds between a Meter Report being send to controller. (default: 120 [s], range: 60 - 65535)",
-						"nl": "De tijd in seconden tussen de Meter rapportages die naar de controller worden verzonden. (standaard: 120 [s], bereik: 60 - 65535)"
+						"en": "#2. The amount of seconds between a Meter Report being send to controller. (default: 120 [s], range: 60 - 65535)",
+						"nl": "#2. De tijd in seconden tussen de Meter rapportages die naar de controller worden verzonden. (standaard: 120 [s], bereik: 60 - 65535)"
 					}
 				},
 				{
@@ -145,12 +145,12 @@
 					},
 					"value": 12,
 					"label": {
-						"en": "3. Maximum over-load current [A]",
-						"nl": "3. Maximale over-load stroom [A]"
+						"en": "Maximum over-load current [A]",
+						"nl": "Maximale over-load stroom [A]"
 					},
 					"hint": {
-						"en": "Defines the maximum current the plug can provide to the device connected to it. If the current consumed is greater than the value set, the plug will cut power. (default: 12 [A], range: 1 - 12)",
-						"nl": "Specificeert de maximale stroom dat de power plug mag leveren aan het apparaat dat aan de power plug gekoppeld is. Wanneer het huidige stroomverbruik groter is dan de ingestelde waarde, wordt de power plug uitgeschakeld. (standaard: 12 [A], bereik: 1 - 12)"
+						"en": "#3. Defines the maximum current the plug can provide to the device connected to it. If the current consumed is greater than the value set, the plug will cut power. (default: 12 [A], range: 1 - 12)",
+						"nl": "#3. Specificeert de maximale stroom dat de power plug mag leveren aan het apparaat dat aan de power plug gekoppeld is. Wanneer het huidige stroomverbruik groter is dan de ingestelde waarde, wordt de power plug uitgeschakeld. (standaard: 12 [A], bereik: 1 - 12)"
 					}
 				},
 				{
@@ -162,25 +162,25 @@
 					},
 					"value": 12,
 					"label": {
-						"en": "4. Upper alarm current [A]",
-						"nl": "4. Alarm stroom [A]"
+						"en": "Upper alarm current [A]",
+						"nl": "Bovenwaarde alarm stroom [A]"
 					},
 					"hint": {
-						"en": "Defines the current the plug is allowed to provide to the device connected to it. If the alarm current is exceeded, the plug will send an alarm notification to the controller and LED will turn RED. Value specified has to be less or equal to #3. (default: 12 [A], range: 1 - 12)",
-						"nl": "Specificeert de maximale stroom dat de power plug mag leveren aan het apparaat dat aan de power plug gekoppeld is. Wanneer het alarm stroom overschreden wordt, zal de power plug een alarm naar de controller versturen en de LED rood kleuren. De waarde moet kleiner of gelijk zijn aan #3. (standaard: 12 [A], bereik: 1 - 12)"
+						"en": "#4. Defines the current the plug is allowed to provide to the device connected to it. If the alarm current is exceeded, the plug will send an alarm notification to the controller and LED will turn RED. Value specified has to be less or equal to #3. (default: 12 [A], range: 1 - 12)",
+						"nl": "#4. Specificeert de maximale stroom dat de power plug mag leveren aan het apparaat dat aan de power plug gekoppeld is. Wanneer het alarm stroom overschreden wordt, zal de power plug een alarm naar de controller versturen en de LED rood kleuren. De waarde moet kleiner of gelijk zijn aan #3. (standaard: 12 [A], bereik: 1 - 12)"
 					}
 				},
 				{
 				    "id": "led_display",
 				    "type": "checkbox",
 				    "label": {
-					    "en": "5. State indication Led",
-						"nl": "5. Status indicatie Led"
+					    "en": "Enable state indication Led",
+						"nl": "Status indicatie Led inschakelen"
 				    },
 				    "value": true,
 				    "hint": {
-					    "en": "This will Disable/Enable the status led on top. (default: enabled = checked)",
-						"nl": "Hiermee schakelt u de functie van de status led aan of uit. (standaard: ingeschakeld = checked)"
+					    "en": "#5. Enable (checked) or disable (unchecked) the status led on top. (default: enabled = checked)",
+						"nl": "#5. Schakel de status indicatie led aan (checked) of uit (unchecked). (standaard: ingeschakeld = checked)"
 				    }
 			    },
 				{
@@ -192,38 +192,38 @@
 					},
 					"value": 80,
 					"label": {
-						"en": "6. Power consumed change resulting [%]",
-						"nl": "6. Procentuele wijziging van het vermogen [%]"
+						"en": "Power consumed change resulting [%]",
+						"nl": "Procentuele wijziging van het vermogen [%]"
 					},
 					"hint": {
-						"en": "The amount of power consumed must change to be reported to the controller. (default: 80 [%], range: 1 - 100)",
-						"nl": "De wijziging van die het vermogen moet ondergaan om gerapporteerd te worden naar de controller. (standaard: 80 [%], bereik: 1 - 100)"
+						"en": "#6. The amount of power consumed must change to be reported to the controller. (default: 80 [%], range: 1 - 100)",
+						"nl": "#6. De wijziging van die het vermogen moet ondergaan om gerapporteerd te worden naar de controller. (standaard: 80 [%], bereik: 1 - 100)"
 					}
 				},
 				{
 				    "id": "remember_state",
 				    "type": "checkbox",
 				    "label": {
-					    	"en": "7. Return to last known state after power loss",
-						"nl": "7. Keer terug naar laatst bekende status bij spanningsuitval"
+					    	"en": "Return to last known state after power loss",
+						"nl": "Keer terug naar laatst bekende status bij spanningsuitval"
 				    },
 				    "value": true,
 				    "hint": {
-					    	"en": "After power loss the state of the relay will switch to last known. (default: enabled = checked)",
-						"nl": "Schakel terug naar laatst bekende schakelstand na spanningsuitval. (standaard: uitgeschakeld = unchecked)"
+					    	"en": "#7. After power loss the relay will switch to last known state if enabled (checked) or remain off if disabled (unchecked). (default: enabled = checked)",
+						"nl": "#7. Schakel terug naar laatst bekende schakelstand na spanningsuitval wanneer ingeschakeld (checked) of uit wanneer niet ingeschakeld (unchecked). (standaard: uitgeschakeld = unchecked)"
 				    }
 			    	},
 				{
 				    "id": "time_switch_function",
 				    "type": "checkbox",
 				    "label": {
-					    	"en": "8. Enable power plug time switch function",
-						"nl": "8. Power plug tijd schakelings functie"
+					    	"en": "Enable power plug time switch function",
+						"nl": "Power plug tijd schakelings functie"
 				    },
 				    "value": false,
 				    "hint": {
-					    	"en": "Enables or disables the time switch function. When enabled, the power plug, after being switched on, will switch off after the in #9 defined time. (default: disabled = unchecked)",
-						"nl": "Aan of uitzetten tijd schakelings functie. Wanneer ingeschakeld zal de power plug na ingeschakeld te zijn, automatisch uitschakelen na de in #9 gedefinieerde tijd. (standaard: uitgeschakeld = unchecked)"
+					    	"en": "#8. Enables or disables the time switch function. When enabled (checked), the power plug, after being switched on, will switch off after the in #9 defined time. (default: disabled = unchecked)",
+						"nl": "#8. Aan of uitzetten tijd schakelings functie. Wanneer ingeschakeld (checked) zal de power plug na ingeschakeld te zijn, automatisch uitschakelen na de in #9 gedefinieerde tijd. (standaard: uitgeschakeld = unchecked)"
 				    }
 			    	},
 				{
@@ -235,17 +235,16 @@
 					},
 					"value": 150,
 					"label": {
-						"en": "9. Time period to switch off plug [min]",
-						"nl": "9. Tijdsduur voor het uitschakelen [min]"
+						"en": "Time period to switch off plug [min]",
+						"nl": "Tijdsduur voor het uitschakelen van de power plug [min]"
 					},
 					"hint": {
-						"en": "The time period before switching off the power plug, if time function has been enabled in #8. (default: 150 [min], range: 1 - 65535)",
-						"nl": "De tijdsduur waarna de power plug zal uitschakelen, wanneer de tijd schakelings functie ingeschakeld is in #8. (standaard: 150 [min], bereik: 1 - 65535)"
+						"en": "#9. The time period before switching off the power plug, if time function has been enabled in #8. (default: 150 [min], range: 1 - 65535)",
+						"nl": "#9. De tijdsduur waarna de power plug zal uitschakelen, wanneer de tijd schakelings functie ingeschakeld is in #8. (standaard: 150 [min], bereik: 1 - 65535)"
 					}
 				}
 			]
 		},
-
 		{
 			"id": "NAS-DS01ZE",
 			"name": {

--- a/app.json
+++ b/app.json
@@ -47,6 +47,26 @@
 					}
 				},
 				"associationGroups": [ 1 ],
+				"associationGroupsOptions": {
+					"1": {
+						"hint": {
+							"en": "Reports the lifeline service that assigned to plug status – ON/OFF. It enables the Plug to send reports and readings to the Z-Wave Controller. (Homey ID by default). It is not recommended to change this group.",
+							"nl": "Rapportage van de status van de power plug en staat controle (AAN/UIT) over de power plug toe (Homey ID als standaard waarde). Het is niet aanbevolen om deze groep aan te passen."
+						}
+					},
+					"2": {
+						"hint": {
+							"en": "Allows for sending alarm commands to associated devices such as Siren, relay module, lighting, etc. If current load is over the max current defined in parameter #3, the Plug will send a alarm to the associated devices. (add Z-wave ID of relay devices).",
+							"nl": "Rapportage van een alarm commando naar gekoppelde apparaten, zoals sirene, schakelaar, verlichting, etc. Op het moment dat het stroom hoger is dan gedefinieerd in parameter #3, wordt een alarm naar de gekoppelde apparaten gestuurd (voeg het Z-wave ID van het te koppelen apparaat toe)."
+						}
+					},
+					"3": {
+						"hint": {
+							"en": "Allows for Send Notification to associated devices in this group (add Z-wave ID of relay devices).",
+							"nl": "Rapportage van een notificatie naar de gekoppelde apparaten. (voeg het Z-wave ID van het te koppelen apparaat toe)"
+						}
+					}
+				},
 				"defaultConfiguration": [
 					{
 						"id": 1,

--- a/app.json
+++ b/app.json
@@ -110,15 +110,15 @@
 				    "id": "meter_report",
 				    "type": "checkbox",
 				    "label": {
-					    "en": "Meter Report",
-						"nl": "Meter Report"
+					    "en": "1. Meter Report",
+						"nl": "1. Meter Report"
 				    },
 				    "value": true,
 				    "hint": {
-					    "en": "This will Disable/Enable meter report measure data to controller.",
-						"nl": "Dit zal meter rapportages inschakelen naar controller."
+					    "en": "This will Disable/Enable meter report measure data to controller. (default: enabled = checked)",
+						"nl": "Dit zal meter rapportages inschakelen naar controller. (standaard: ingeschakeld = checked)"
 				    }
-			    },
+			    	},
 				{
 					"id": "meter_report_interval",
 					"type": "number",
@@ -128,25 +128,59 @@
 					},
 					"value": 120,
 					"label": {
-						"en": "Meter Report Interval (s)",
-						"nl": "Meter Report Interval (s)"
+						"en": "2. Meter Report Interval [s]",
+						"nl": "2. Meter Report Interval [s]"
 					},
 					"hint": {
-						"en": "The amount of seconds between a Meter Report being send to controller.",
-						"nl": "De tijd in seconden tussen de Meter rapportages die naar de controller worden verzonden."
+						"en": "The amount of seconds between a Meter Report being send to controller. (default: 120 [s], range: 60 - 65535)",
+						"nl": "De tijd in seconden tussen de Meter rapportages die naar de controller worden verzonden. (standaard: 120 [s], bereik: 60 - 65535)"
+					}
+				},
+				{
+					"id": "over_load_current",
+					"type": "number",
+					"attr": {
+						"min": 1,
+						"max": 16
+					},
+					"value": 12,
+					"label": {
+						"en": "3. Maximum over-load current [A]",
+						"nl": "3. Maximale over-load stroom [A]"
+					},
+					"hint": {
+						"en": "Defines the maximum current the plug can provide to the device connected to it. If the current consumed is greater than the value set, the plug will cut power. (default: 12 [A], range: 1 - 12)",
+						"nl": "Specificeert de maximale stroom dat de power plug mag leveren aan het apparaat dat aan de power plug gekoppeld is. Wanneer het huidige stroomverbruik groter is dan de ingestelde waarde, wordt de power plug uitgeschakeld. (standaard: 12 [A], bereik: 1 - 12)"
+					}
+				},
+				{
+					"id": "alarm_current",
+					"type": "number",
+					"attr": {
+						"min": 1,
+						"max": 16
+					},
+					"value": 12,
+					"label": {
+						"en": "4. Upper alarm current [A]",
+						"nl": "4. Alarm stroom [A]"
+					},
+					"hint": {
+						"en": "Defines the current the plug is allowed to provide to the device connected to it. If the alarm current is exceeded, the plug will send an alarm notification to the controller and LED will turn RED. Value specified has to be less or equal to #3. (default: 12 [A], range: 1 - 12)",
+						"nl": "Specificeert de maximale stroom dat de power plug mag leveren aan het apparaat dat aan de power plug gekoppeld is. Wanneer het alarm stroom overschreden wordt, zal de power plug een alarm naar de controller versturen en de LED rood kleuren. De waarde moet kleiner of gelijk zijn aan #3. (standaard: 12 [A], bereik: 1 - 12)"
 					}
 				},
 				{
 				    "id": "led_display",
 				    "type": "checkbox",
 				    "label": {
-					    "en": "State indication Led",
-						"nl": "Status indicatie Led"
+					    "en": "5. State indication Led",
+						"nl": "5. Status indicatie Led"
 				    },
 				    "value": true,
 				    "hint": {
-					    "en": "This will Disable/Enable the status led on top.",
-						"nl": "Hiermee schakelt u de functie van de status led aan of uit."
+					    "en": "This will Disable/Enable the status led on top. (default: enabled = checked)",
+						"nl": "Hiermee schakelt u de functie van de status led aan of uit. (standaard: ingeschakeld = checked)"
 				    }
 			    },
 				{
@@ -158,28 +192,57 @@
 					},
 					"value": 80,
 					"label": {
-						"en": "Power consumed change resulting (%)",
-						"nl": "Procentuele wijziging van het vermogen (%)"
+						"en": "6. Power consumed change resulting [%]",
+						"nl": "6. Procentuele wijziging van het vermogen [%]"
 					},
 					"hint": {
-						"en": "The amount of power consumed must change to be reported to the controller.",
-						"nl": "De wijziging van die het vermogen moet ondergaan om gerapporteerd te worden naar de controller."
+						"en": "The amount of power consumed must change to be reported to the controller. (default: 80 [%], range: 1 - 100)",
+						"nl": "De wijziging van die het vermogen moet ondergaan om gerapporteerd te worden naar de controller. (standaard: 80 [%], bereik: 1 - 100)"
 					}
 				},
 				{
 				    "id": "remember_state",
 				    "type": "checkbox",
 				    "label": {
-					    "en": "Return to last known state after power loss",
-						"nl": "Keer terug naar laatst bekende status bij spanningsuitval"
+					    	"en": "7. Return to last known state after power loss",
+						"nl": "7. Keer terug naar laatst bekende status bij spanningsuitval"
 				    },
 				    "value": true,
 				    "hint": {
-					    "en": "After power loss the state of the relay will switch to last known.",
-						"nl": "Schakel terug naar laatst bekende schakelstand na spanningsuitval"
+					    	"en": "After power loss the state of the relay will switch to last known. (default: enabled = checked)",
+						"nl": "Schakel terug naar laatst bekende schakelstand na spanningsuitval. (standaard: uitgeschakeld = unchecked)"
 				    }
-			    }
-
+			    	},
+				{
+				    "id": "time_switch_function",
+				    "type": "checkbox",
+				    "label": {
+					    	"en": "8. Enable power plug time switch function",
+						"nl": "8. Power plug tijd schakelings functie"
+				    },
+				    "value": false,
+				    "hint": {
+					    	"en": "Enables or disables the time switch function. When enabled, the power plug, after being switched on, will switch off after the in #9 defined time. (default: disabled = unchecked)",
+						"nl": "Aan of uitzetten tijd schakelings functie. Wanneer ingeschakeld zal de power plug na ingeschakeld te zijn, automatisch uitschakelen na de in #9 gedefinieerde tijd. (standaard: uitgeschakeld = unchecked)"
+				    }
+			    	},
+				{
+					"id": "time_switch_period",
+					"type": "number",
+					"attr": {
+						"min": 1,
+						"max": 65535
+					},
+					"value": 150,
+					"label": {
+						"en": "9. Time period to switch off plug [min]",
+						"nl": "9. Tijdsduur voor het uitschakelen [min]"
+					},
+					"hint": {
+						"en": "The time period before switching off the power plug, if time function has been enabled in #8. (default: 150 [min], range: 1 - 65535)",
+						"nl": "De tijdsduur waarna de power plug zal uitschakelen, wanneer de tijd schakelings functie ingeschakeld is in #8. (standaard: 150 [min], bereik: 1 - 65535)"
+					}
+				}
 			]
 		},
 

--- a/drivers/NAS-WR01ZE/driver.js
+++ b/drivers/NAS-WR01ZE/driver.js
@@ -77,6 +77,14 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
                 "index": 2,
                 "size": 2
                 },
+		"over_load_current": {
+                "index": 3,
+                "size": 1
+                },
+		"alarm_current": {
+                "index": 4,
+                "size": 1
+                },
                 "led_display": {
                 "index": 5,
                 "size": 1,
@@ -84,12 +92,21 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
                 },
                 "power_report_change": {
                 "index": 6,
-                "size": 1,
+                "size": 1
                 },
 		"remember_state": {
                 "index": 7,
                 "size": 1,
                 "parser": value => new Buffer([ ( value === true ) ? 0 : 1 ])
+                },
+		"time_switch_function": {
+                "index": 8,
+                "size": 1,
+		"parser": value => new Buffer([ ( value === true ) ? 0 : 1 ])
+                },
+		"time_switch_period": {
+                "index": 9,
+                "size": 1
                 }
               }
 })

--- a/drivers/NAS-WR01ZE/driver.js
+++ b/drivers/NAS-WR01ZE/driver.js
@@ -71,7 +71,7 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
                 "meter_report": {
                 "index": 1,
                 "size": 1,
-                "parser": value => new Buffer([ ( value === true ) ? 0 : 1 ])
+                "parser": value => new Buffer([ ( value === true ) ? 1 : 0 ])
                   },
 		"meter_report_interval": {
                 "index": 2,
@@ -85,24 +85,24 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
                 "index": 4,
                 "size": 1
                 },
-                "led_display": {
+        	"led_display": {
                 "index": 5,
                 "size": 1,
-                "parser": value => new Buffer([ ( value === true ) ? 0 : 1 ])
+                "parser": value => new Buffer([ ( value === true ) ? 1 : 0 ])
                 },
-                "power_report_change": {
+        	"power_report_change": {
                 "index": 6,
                 "size": 1
                 },
 		"remember_state": {
                 "index": 7,
                 "size": 1,
-                "parser": value => new Buffer([ ( value === true ) ? 0 : 1 ])
+                "signed": false,
                 },
 		"time_switch_function": {
                 "index": 8,
                 "size": 1,
-		"parser": value => new Buffer([ ( value === true ) ? 0 : 1 ])
+				"parser": value => new Buffer([ ( value === true ) ? 1 : 0 ])
                 },
 		"time_switch_period": {
                 "index": 9,

--- a/drivers/NAS-WR01ZE/driver.js
+++ b/drivers/NAS-WR01ZE/driver.js
@@ -20,7 +20,7 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 				return report['Value'] === 'on/enable';
 			}
 		},
-			'measure_power': {
+		'measure_power': {
 			'command_class': 'COMMAND_CLASS_METER',
 			'command_get': 'METER_GET',
 			'command_get_parser': () => {
@@ -41,9 +41,7 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 				return null;
 				},
 			},
-			
-			
-			'meter_power': {
+		'meter_power': {
 			'command_class': 'COMMAND_CLASS_METER',
 			'command_get': 'METER_GET',
 			'command_get_parser': () => {
@@ -58,16 +56,16 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 				'command_report': 'METER_REPORT',
 				'command_report_parser': report => {
 				if (report.hasOwnProperty('Properties2') &&
+				report.Properties2.hasOwnProperty('Size') &&
+				report.Properties2['Size'] === 4 &&
 				report.Properties2.hasOwnProperty('Scale bits 10') &&
-				report.Properties2['Scale bits 10'] === 1)
+				report.Properties2['Scale bits 10'] === 0)
 				return report['Meter Value (Parsed)'];
 				return null;
 				},
 			}
-			
-		
 		},
-	    settings: {
+	settings: {
                 "meter_report": {
                 "index": 1,
                 "size": 1,


### PR DESCRIPTION
Main changes:
- Add custom group hints to power plug
- Completed settings of power plug (no 3, no 4, no 8, no 9)
- Updated defaultConfiguration (in particular no 7) to secure that the right values are parsed
- Updated parsers for the checkbox parameters; 0 was linked to true instead of 1 -> corrected and tested
- Removed parser no 7, with original parser the function became broken after update of parameter value -> corrected and tested
- Updated meter_power (showing correct kwh)
- Updated Readme to include changelog
- Textual changes: updated labels and hints for parameters & updated hints for association groups
