### PR TITLE
Proposed version bump to 1.1.6 - include measure current and measure voltage to insights / mobile card

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Makes Homey work with these nice and cheap chinese z-wave products
 **update:**
 NAS-WR01ZE - Updated mobile card & insights logging to include current and voltage
 
-**note:**
-re-pair of Power Plug required to make use of this update
+note: re-pair of Power Plug required to make use of this update
 
 ### v 1.1.5
 **add support:**  

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Makes Homey work with these nice and cheap chinese z-wave products
 NAS-WR01ZE - Updated mobile card & insights logging to include current and voltage
 
 **note:**
-* re-pair of Power Plug required to make use of this update
+re-pair of Power Plug required to make use of this update
 
 ### v 1.1.5
 **add support:**  

--- a/README.md
+++ b/README.md
@@ -10,20 +10,23 @@ Makes Homey work with these nice and cheap chinese z-wave products
 * NAS-DS01ZE, Door Sensor
 * NAS-WS01ZE, Flood Sensor
 
+## Supported Languages:
+* English
+* Dutch (Nederlands)
+
 ## Todo
 * Add more settings to devices
-* Custom mobile card on Wall Plug 
 
 ## Change Log:
 ### v 1.1.6
 **update:**
 NAS-WR01ZE - Updated mobile card & insights logging to include current and voltage
-
-note: re-pair of Power Plug required to make use of this update
+**note**
+note: re-pair of Power Plug required to make use of current and voltage reporting capabilities
 
 ### v 1.1.5
 **add support:**  
 NAS-WR01ZE - Additional settings implemented (e.g. over-load current, alarm current, time switch function)
-
 **update:**  
-NAS-WR01ZE - Bug fixes defaultConfiguration and parameters, implementation of power consumption (kWh), textual fixes (setting-labels, -hints and association group-hints)
+NAS-WR01ZE - Bug fixes defaultConfiguration and parameters, implementation of power consumption (kWh)
+NAS-WR01ZE - textual fixes (setting-labels, -hints and association group-hints)

--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ Makes Homey work with these nice and cheap chinese z-wave products
 ### v 1.1.6
 **update:**
 NAS-WR01ZE - Updated mobile card & insights logging to include current and voltage
+
 **note:**
 * re-pair of Power Plug required to make use of this update
 
 ### v 1.1.5
 **add support:**  
 NAS-WR01ZE - Additional settings implemented (e.g. over-load current, alarm current, time switch function)
+
 **update:**  
 NAS-WR01ZE - Bug fixes defaultConfiguration and parameters, implementation of power consumption (kWh), textual fixes (setting-labels, -hints and association group-hints)

--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ Makes Homey work with these nice and cheap chinese z-wave products
 ## Change Log:
 ### v 1.1.6
 **update:**
-NAS-WR01ZE - Updated mobile card & insights logging to include current and voltage
-**note**
-note: re-pair of Power Plug required to make use of current and voltage reporting capabilities
+* NAS-WR01ZE - Updated mobile card & insights logging to include current and voltage
+
+**notes**
+* re-pair of Power Plug required to make use of current and voltage reporting capabilities
 
 ### v 1.1.5
 **add support:**  
-NAS-WR01ZE - Additional settings implemented (e.g. over-load current, alarm current, time switch function)
+* NAS-WR01ZE - Additional settings implemented (e.g. over-load current, alarm current, time switch function)
+
 **update:**  
-NAS-WR01ZE - Bug fixes defaultConfiguration and parameters, implementation of power consumption (kWh)
-NAS-WR01ZE - textual fixes (setting-labels, -hints and association group-hints)
+* NAS-WR01ZE - Bug fixes defaultConfiguration and parameters, implementation of power consumption (kWh)
+* NAS-WR01ZE - textual fixes (setting-labels, -hints and association group-hints)

--- a/README.md
+++ b/README.md
@@ -19,16 +19,15 @@ Makes Homey work with these nice and cheap chinese z-wave products
 
 ## Change Log:
 ### v 1.1.6
-**update:**
-* NAS-WR01ZE - Updated mobile card & insights logging to include current and voltage
-
-**notes**
-* re-pair of Power Plug required to make use of current and voltage reporting capabilities
+**update:**   
+NAS-WR01ZE - Updated mobile card & insights logging to include current and voltage   
+Z-Wave Driver (v1.1.2)   
+**notes**   
+re-pair of Power Plug required to make use of current and voltage reporting capabilities   
 
 ### v 1.1.5
-**add support:**  
-* NAS-WR01ZE - Additional settings implemented (e.g. over-load current, alarm current, time switch function)
-
-**update:**  
-* NAS-WR01ZE - Bug fixes defaultConfiguration and parameters, implementation of power consumption (kWh)
-* NAS-WR01ZE - textual fixes (setting-labels, -hints and association group-hints)
+**add support:**   
+NAS-WR01ZE - Additional settings implemented (e.g. over-load current, alarm current, time switch function)   
+**update:**     
+NAS-WR01ZE - Bug fixes defaultConfiguration and parameters, implementation of power consumption (kWh)   
+NAS-WR01ZE - textual fixes (setting-labels, -hints and association group-hints)   

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Makes Homey work with these nice and cheap chinese z-wave products
 * Custom mobile card on Wall Plug 
 
 ## Change Log:
+### v 1.1.6
+**update:**
+NAS-WR01ZE - Updated mobile card & insights logging to include current and voltage
+**note:**
+* re-pair of Power Plug required to make use of this update
+
 ### v 1.1.5
 **add support:**  
 NAS-WR01ZE - Additional settings implemented (e.g. over-load current, alarm current, time switch function)

--- a/app.json
+++ b/app.json
@@ -29,6 +29,44 @@
 			}
 		]
 	},
+	"capabilities": {
+		"measure_current": {
+					"type": "number",
+					"title": {
+						"en": "Current",
+						"nl": "Stroom"
+						},
+					"units": {
+						"en": "A"
+						},
+					"desc": {
+						"en": "Electric current(A)",
+						"nl": "Elektrische stroom (A)"
+						},
+					"chartType": "stepLine",
+					"decimals": 2,
+					"getable": true,
+					"setable": false
+					},
+				"measure_voltage": {
+					"type": "number",
+					"title": {
+						"en": "Voltage",
+						"nl": "Spanning"
+						},
+					"units": {
+						"en": "V"
+						},
+					"desc": {
+						"en": "Voltage (V)",
+						"nl": "Spanning (V)"
+						},
+					"chartType": "stepLine",
+					"decimals": 0,
+					"getable": true,
+					"setable": false
+					}
+		},
 	"drivers": [
 		  {
 			"id": "NAS-WR01ZE",
@@ -98,13 +136,38 @@
 			"class": "socket",
 			"capabilities": [
 				"onoff",
+				"meter_power",
 				"measure_power",
-				"meter_power"
+				"measure_current",
+				"measure_voltage"
 			],
 			"images": {
 				"large": "/drivers/NAS-WR01ZE/assets/images/large.jpg",
 				"small": "/drivers/NAS-WR01ZE/assets/images/small.jpg"
 			},
+			"mobile": {
+            "components": [
+                {
+					"id": "icon",
+					"capabilities": [ "onoff" ]
+				},
+				{
+                    "id": "sensor",
+                    "capabilities": [ "meter_power", "measure_power","measure_current", "measure_voltage" ],
+                    "options": {
+    					"icons": {
+        					"measure_current": "/drivers/NAS-WR01ZE/assets/measure_current.svg",
+        					"measure_voltage": "/drivers/NAS-WR01ZE/assets/measure_voltage.svg",
+        					"measure_power": "/drivers/NAS-WR01ZE/assets/measure_power.svg"
+    							}
+                	}
+                },
+                {
+                    "id": "toggle",
+                    "capabilities": [ "onoff" ]
+                }
+            ]
+        	},
 			"settings": [
 				{
 				    "id": "meter_report",

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
 	"name": {
 		"en": "NEO Coolcam Z-Wave Products"
 	},
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"compatibility": ">=1.0.1",
 	"description": {
 		"en": "NEO Coolcam Z-Wave products"

--- a/drivers/NAS-WR01ZE/assets/measure_current.svg
+++ b/drivers/NAS-WR01ZE/assets/measure_current.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="-362.7 661.4 132.2 132.3"
+   style="enable-background:new -362.7 661.4 132.2 132.3;"
+   xml:space="preserve"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="measure_current.svg"><metadata
+     id="metadata3432"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs3430" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1440"
+     inkscape:window-height="811"
+     id="namedview3428"
+     showgrid="false"
+     inkscape:zoom="6.51"
+     inkscape:cx="91.621319"
+     inkscape:cy="36.426837"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style3420">
+	.st0{opacity:0;}
+</style><rect
+     x="-362.7"
+     y="661.4"
+     class="st0"
+     width="132.2"
+     height="132.2"
+     id="rect3422" /><polygon
+     points="-301.4,661.4 -269.4,661.4 -289.3,700.7 -259.7,700.7 -325.8,793.7 -299.4,724.3 -325.8,724.3 "
+     id="polygon3424" /><flowRoot
+     xml:space="preserve"
+     id="flowRoot3434"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     transform="translate(-362.70001,661.40002)"><flowRegion
+       id="flowRegion3436"><rect
+         id="rect3438"
+         width="44.534485"
+         height="43.231037"
+         x="86.244827"
+         y="89.06897" /></flowRegion><flowPara
+       id="flowPara3440">P</flowPara></flowRoot><text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:57.5px;line-height:300%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="-262.29828"
+     y="793.36926"
+     id="text3446-0"
+     sodipodi:linespacing="300%"><tspan
+       sodipodi:role="line"
+       id="tspan3448-2"
+       x="-262.29828"
+       y="793.36926"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:57.5px;line-height:300%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start">I</tspan></text>
+</svg>

--- a/drivers/NAS-WR01ZE/assets/measure_power.svg
+++ b/drivers/NAS-WR01ZE/assets/measure_power.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="-362.7 661.4 132.2 132.3"
+   style="enable-background:new -362.7 661.4 132.2 132.3;"
+   xml:space="preserve"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="measure_power.svg"><metadata
+     id="metadata3432"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs3430" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1440"
+     inkscape:window-height="811"
+     id="namedview3428"
+     showgrid="false"
+     inkscape:zoom="6.51"
+     inkscape:cx="91.621319"
+     inkscape:cy="36.426837"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style3420">
+	.st0{opacity:0;}
+</style><rect
+     x="-362.7"
+     y="661.4"
+     class="st0"
+     width="132.2"
+     height="132.2"
+     id="rect3422" /><polygon
+     points="-301.4,661.4 -269.4,661.4 -289.3,700.7 -259.7,700.7 -325.8,793.7 -299.4,724.3 -325.8,724.3 "
+     id="polygon3424" /><flowRoot
+     xml:space="preserve"
+     id="flowRoot3434"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     transform="translate(-362.70001,661.40002)"><flowRegion
+       id="flowRegion3436"><rect
+         id="rect3438"
+         width="44.534485"
+         height="43.231037"
+         x="86.244827"
+         y="89.06897" /></flowRegion><flowPara
+       id="flowPara3440">P</flowPara></flowRoot><text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:57.5px;line-height:300%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="-272.9953"
+     y="793.36926"
+     id="text3446"
+     sodipodi:linespacing="300%"><tspan
+       sodipodi:role="line"
+       id="tspan3448"
+       x="-272.9953"
+       y="793.36926"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:57.5px;line-height:300%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start">P</tspan></text>
+</svg>

--- a/drivers/NAS-WR01ZE/assets/measure_voltage.svg
+++ b/drivers/NAS-WR01ZE/assets/measure_voltage.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="-362.7 661.4 132.2 132.3"
+   style="enable-background:new -362.7 661.4 132.2 132.3;"
+   xml:space="preserve"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="measure_voltage.svg"><metadata
+     id="metadata3432"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs3430" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1440"
+     inkscape:window-height="811"
+     id="namedview3428"
+     showgrid="false"
+     inkscape:zoom="6.51"
+     inkscape:cx="91.621319"
+     inkscape:cy="36.426837"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style3420">
+	.st0{opacity:0;}
+</style><rect
+     x="-362.7"
+     y="661.4"
+     class="st0"
+     width="132.2"
+     height="132.2"
+     id="rect3422" /><polygon
+     points="-301.4,661.4 -269.4,661.4 -289.3,700.7 -259.7,700.7 -325.8,793.7 -299.4,724.3 -325.8,724.3 "
+     id="polygon3424" /><flowRoot
+     xml:space="preserve"
+     id="flowRoot3434"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     transform="translate(-362.70001,661.40002)"><flowRegion
+       id="flowRegion3436"><rect
+         id="rect3438"
+         width="44.534485"
+         height="43.231037"
+         x="86.244827"
+         y="89.06897" /></flowRegion><flowPara
+       id="flowPara3440">P</flowPara></flowRoot><text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:57.5px;line-height:300%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="-273.4726"
+     y="793.36926"
+     id="text3446-1"
+     sodipodi:linespacing="300%"><tspan
+       sodipodi:role="line"
+       id="tspan3448-1"
+       x="-273.4726"
+       y="793.36926"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:57.5px;line-height:300%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start">V</tspan></text>
+</svg>

--- a/drivers/NAS-WR01ZE/driver.js
+++ b/drivers/NAS-WR01ZE/driver.js
@@ -63,6 +63,52 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 				return report['Meter Value (Parsed)'];
 				return null;
 				},
+			},
+		'measure_voltage': {
+			'command_class': 'COMMAND_CLASS_METER',
+			'command_get': 'METER_GET',
+			'command_get_parser': () => {
+			return {
+				'Properties1': {
+				'Rate Type': 'Import',
+				'Scale': 2
+					},
+					'Scale 2': 0
+					};
+				},
+				'command_report': 'METER_REPORT',
+				'command_report_parser': report => {
+				if (report.hasOwnProperty('Properties2') &&
+				report.Properties2.hasOwnProperty('Size') &&
+				report.Properties2['Size'] === 2 &&
+				report.Properties2.hasOwnProperty('Scale bits 10') &&
+				report.Properties2['Scale bits 10'] === 0)
+				return report['Meter Value (Parsed)'];
+				return null;
+				},
+			},
+		'measure_current': {
+			'command_class': 'COMMAND_CLASS_METER',
+			'command_get': 'METER_GET',
+			'command_get_parser': () => {
+			return {
+				'Properties1': {
+				'Rate Type': 'Import',
+				'Scale': 2
+					},
+					'Scale 2': 0
+					};
+				},
+				'command_report': 'METER_REPORT',
+				'command_report_parser': report => {
+				if (report.hasOwnProperty('Properties2') &&
+				report.Properties2.hasOwnProperty('Size') &&
+				report.Properties2['Size'] === 2 &&
+				report.Properties2.hasOwnProperty('Scale bits 10') &&
+				report.Properties2['Scale bits 10'] === 1)
+				return report['Meter Value (Parsed)'];
+				return null;
+				},
 			}
 		},
 	settings: {

--- a/node_modules/homey-zwavedriver/README.md
+++ b/node_modules/homey-zwavedriver/README.md
@@ -1,11 +1,15 @@
 # ZwaveDriver
 Generic class to map Z-Wave CommandClasses to Homey capabilities, for faster Z-Wave App development.
 
+## Z-Wave docs
+
+Please also read the Homey Z-Wave docs here: [https://developers.athom.com/library/zwave/](https://developers.athom.com/library/zwave/)
+
 ## Installation
 
 ```
 cd /path/to/com.your.homeyapp/
-npm install --save https://github.com/athombv/node-homey-zwavedriver
+git submodule add git@github.com:athombv/node-homey-zwavedriver.git node_modules/homey-zwavedriver
 ```
 
 ## Example
@@ -13,7 +17,7 @@ npm install --save https://github.com/athombv/node-homey-zwavedriver
 File: `/drivers/mydriver/driver.js`
 
 ```javascript
-"use strict";
+'use strict';
 
 const ZwaveDriver = require('homey-zwavedriver');
 
@@ -32,7 +36,8 @@ module.exports = new ZwaveDriver('mydriver', {
 			'command_report'			: 'SWITCH_BINARY_REPORT',
 			'command_report_parser'		: function( report ){
 				return report['Value'] === 'on/enable';
-			}
+			},
+			'getOnWakeUp': true, // if set to true and device is battery powered this capability will perform a GET everytime the device wakes up
 		},
 		'measure_power': {
 			'command_class'				: 'COMMAND_CLASS_SENSOR_MULTILEVEL',
@@ -44,27 +49,34 @@ module.exports = new ZwaveDriver('mydriver', {
 			'optional': true // if device variably advertises a command class (e.g. cc battery when dc-powered) set this variable to true to prevent crashes
 		}
 	},
+	beforeInit: (token, callback) => {
+	    // this method is called right before the initialization of a device (before it gets marked as available)
+	},
 	settings: {
-		"always_on": {
-			"index": 1,
-			"size": 1,
-			"parser": function( input ) {
-				return new Buffer([ ( input === true ) ? 0 : 1 ]);
-			}
+		'always_on': {
+			'index': 1,
+			'size': 1
 		},
-		"led_ring_color_on": {
-			"index": 61,
-			"size": 1,
-			"parser": function( input ) {
+		'led_ring_color_on': {
+			'index': 61,
+			'size': 1,
+			
+			// define a custom parser method (optional)
+			'parser': function( input ) {
 				return new Buffer([ parseInt(input) ]);
 			}
 		},
-		"led_ring_color_off": {
-			"index": 62,
-			"size": 1,
-			"parser": function( input ) {
-				return new Buffer([ parseInt(input) ]);
-			}
+		'led_ring_color_off': {
+			'index': 62,
+			'size': 1
+		},
+		'sensitivity': {
+			'index': 63,
+			'size': 1,
+			
+			// set signed to false to let (0, 255) scale to (0x00, 0xFF)
+			// otherwise the domain is (-128, 127) for size=1
+			'signed': false
 		}
 	}
 });

--- a/node_modules/homey-zwavedriver/lib/ZwaveDriver.js
+++ b/node_modules/homey-zwavedriver/lib/ZwaveDriver.js
@@ -225,11 +225,24 @@ class ZwaveDriver extends events.EventEmitter {
 					|| parseInt(newSettingsObj[changedKey], 10).toString() === newSettingsObj[changedKey]) {
 
 					// Try to write new value  to a buffer
-					try {
-						newValue = new Buffer(settingsObj.size);
-						newValue.writeIntBE(newSettingsObj[changedKey], 0, settingsObj.size);
-					} catch (e) {
-						return this._debug(e);
+					if( settingsObj.signed === false ) {
+
+						try {
+							newValue = new Buffer(settingsObj.size);
+							newValue.writeUIntBE(newSettingsObj[changedKey], 0, settingsObj.size);
+						} catch (e) {
+							return this._debug(e);
+						}
+
+					} else {
+
+						try {
+							newValue = new Buffer(settingsObj.size);
+							newValue.writeIntBE(newSettingsObj[changedKey], 0, settingsObj.size);
+						} catch (e) {
+							return this._debug(e);
+						}
+
 					}
 				} else if (typeof newSettingsObj[changedKey] === 'boolean') {
 					newValue = new Buffer([(newSettingsObj[changedKey] === true) ? 1 : 0]);
@@ -276,14 +289,18 @@ class ZwaveDriver extends events.EventEmitter {
 	 * @param callback
 	 */
 	initNode(deviceData, callback) {
-		callback = callback || function () {
-			};
+		callback = callback || function () {};
 
 		if (!(deviceData && deviceData.token)) return new Error('invalid_device_data');
 
 		// Find z-wave node on network
 		Homey.wireless('zwave').getNode(deviceData, (err, zwaveNode) => {
-			if (err) return callback(err);
+			if (err) {
+				this.setUnavailable( deviceData, err );
+				return callback(err);
+			}
+
+			this.setAvailable( deviceData );
 
 			// Create new object in nodes array
 			this.nodes[deviceData.token] = {

--- a/node_modules/homey-zwavedriver/package.json
+++ b/node_modules/homey-zwavedriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homey-zwavedriver",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Generic class to map Z-Wave CommandClasses to Homey capabilities",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Changes made:
- Add measure_current and measure_voltage to app (mobile card and insights) and driver for the power plug (incl. customized icons), partly resolving #6 
see below screenshots:
<img width="341" alt="schermafbeelding 2017-01-03 om 22 51 40" src="https://cloud.githubusercontent.com/assets/17163431/21625856/19743bdc-d20e-11e6-884e-486f952780b1.png">
<img width="341" alt="schermafbeelding 2017-01-03 om 22 51 29" src="https://cloud.githubusercontent.com/assets/17163431/21625859/1e3d978a-d20e-11e6-9945-c6ee4042485b.png">
- Inclusion of Z-wave driver 1.1.2 