### PR TITLE
Remove reference to old custom capability icons

### DIFF
--- a/app.json
+++ b/app.json
@@ -119,14 +119,7 @@
 				},
 				{
                     "id": "sensor",
-                    "capabilities": [ "meter_power", "measure_power","measure_current", "measure_voltage" ],
-                    "options": {
-    					"icons": {
-        					"measure_current": "/drivers/NAS-WR01ZE/assets/measure_current.svg",
-        					"measure_voltage": "/drivers/NAS-WR01ZE/assets/measure_voltage.svg",
-        					"measure_power": "/drivers/NAS-WR01ZE/assets/measure_power.svg"
-    							}
-                	}
+                    "capabilities": [ "meter_power", "measure_power","measure_current", "measure_voltage" ]
                 },
                 {
                     "id": "toggle",


### PR DESCRIPTION
Icon files are still there to support previous paired devices, but by removing the references in the app.json, these references will not overrule the default capability icons for new devices paired on 1.1.4 ff
Tested on new power plug - OK