### PR TITLE
Issue 148: Not able to set 0 as a value in alarm duration time, fixed

### DIFF
--- a/config/drivers/NAS-WS01ZE.json
+++ b/config/drivers/NAS-WS01ZE.json
@@ -91,7 +91,7 @@
       },
       "type": "number",
       "attr": {
-        "min": 1,
+        "min": 0,
         "max": 255
       },
       "value": 1,


### PR DESCRIPTION
Answer to issue by matrover, set minimum value to 0