### PR TITLE
fix: remove getOnOnline for PIR v1

### DIFF
--- a/drivers/NAS-PD01ZE/device.js
+++ b/drivers/NAS-PD01ZE/device.js
@@ -5,11 +5,7 @@ const {ZwaveDevice} = require('homey-zwavedriver');
 class MultiSensor_PD01Z extends ZwaveDevice {
 
   async onNodeInit() {
-    this.registerCapability('alarm_motion', 'NOTIFICATION', {
-      getOpts: {
-        getOnOnline: true,
-      },
-    });
+    this.registerCapability('alarm_motion', 'NOTIFICATION');
     this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL', {
       getOpts: {
         getOnOnline: true,


### PR DESCRIPTION
Sorry for not being clearer, the meshdriver/zwavedriver update only removes the default `getOnOnline` (which was set for `alarm_tamper`).

Previously `getOnOnline` wouldn't do what you would expect (it wouldn't request the value when the node comes online) but this was fixed in Homey 5.0.0. Given that this previously didn't work it seems safe to remove `getOnOnline` everywhere but I'm not sure if you agree with that point of view.

In this PR I took the reserved approach of removing the `getOnOnline` only for the PIR v1 `alarm_motion` capability.