### PR TITLE
remove getOnOnline for NOTIFICATION capabilities

### DIFF
--- a/drivers/NAS-AB01ZE/device.js
+++ b/drivers/NAS-AB01ZE/device.js
@@ -18,14 +18,6 @@ class Siren_AB01Z extends ZwaveDevice {
       }
     });
     this.registerCapability('alarm_siren', 'NOTIFICATION', {
-      get: 'NOTIFICATION_GET',
-      getOpts: {
-        getOnOnline: true,
-      },
-      getParser: () => ({
-        'V1 Alarm Type': 0,
-        'Notification Type': 'Siren',
-      }),
       report: 'NOTIFICATION_REPORT',
       reportParser: report => {
         if (report && report['Notification Type'] === 'Siren') {

--- a/drivers/NAS-DS01ZE/device.js
+++ b/drivers/NAS-DS01ZE/device.js
@@ -5,11 +5,7 @@ const {ZwaveDevice} = require('homey-zwavedriver');
 class DoorWindowSensor_DS01Z extends ZwaveDevice {
 
   async onNodeInit() {
-    this.registerCapability('alarm_contact', 'NOTIFICATION', {
-      getOpts: {
-        getOnOnline: true,
-      },
-    });
+    this.registerCapability('alarm_contact', 'NOTIFICATION');
     this.registerCapability('measure_battery', 'BATTERY');
   }
 

--- a/drivers/NAS-DS07ZE/device.js
+++ b/drivers/NAS-DS07ZE/device.js
@@ -5,11 +5,7 @@ const {ZwaveDevice} = require('homey-zwavedriver');
 class DoorWindowSensor_DS07Z extends ZwaveDevice {
 
   async onNodeInit() {
-    this.registerCapability('alarm_contact', 'NOTIFICATION', {
-      getOpts: {
-        getOnOnline: true,
-      },
-    });
+    this.registerCapability('alarm_contact', 'NOTIFICATION');
     this.registerCapability('alarm_tamper', 'SENSOR_MULTILEVEL', {
       getOpts: {
         getOnOnline: true,

--- a/drivers/NAS-PD01ZE/device.js
+++ b/drivers/NAS-PD01ZE/device.js
@@ -5,11 +5,7 @@ const {ZwaveDevice} = require('homey-zwavedriver');
 class MultiSensor_PD01Z extends ZwaveDevice {
 
   async onNodeInit() {
-    this.registerCapability('alarm_motion', 'NOTIFICATION', {
-      getOpts: {
-        getOnOnline: true,
-      },
-    });
+    this.registerCapability('alarm_motion', 'NOTIFICATION');
     this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL', {
       getOpts: {
         getOnOnline: true,

--- a/drivers/NAS-PD02ZE/device.js
+++ b/drivers/NAS-PD02ZE/device.js
@@ -5,11 +5,7 @@ const {ZwaveDevice} = require('homey-zwavedriver');
 class MultiSensor_PD02Z extends ZwaveDevice {
 
   async onNodeInit() {
-    this.registerCapability('alarm_motion', 'NOTIFICATION', {
-      getOpts: {
-        getOnOnline: true,
-      },
-    });
+    this.registerCapability('alarm_motion', 'NOTIFICATION');
     this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL', {
       getOpts: {
         getOnOnline: true,

--- a/drivers/NAS-PD03ZE/device.js
+++ b/drivers/NAS-PD03ZE/device.js
@@ -5,11 +5,7 @@ const {ZwaveDevice} = require('homey-zwavedriver');
 class MultiSensor_PD03Z extends ZwaveDevice {
 
   async onNodeInit() {
-    this.registerCapability('alarm_motion', 'NOTIFICATION', {
-      getOpts: {
-        getOnOnline: true,
-      },
-    });
+    this.registerCapability('alarm_motion', 'NOTIFICATION');
     this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL', {
       getOpts: {
         getOnOnline: true,

--- a/drivers/NAS-RC01ZE/device.js
+++ b/drivers/NAS-RC01ZE/device.js
@@ -9,14 +9,6 @@ class KeyFob_RC01Z extends ZwaveDevice {
 	  let PreviousSequenceNo = 'empty';
 	  
 	this.registerCapability('alarm_emergency', 'NOTIFICATION', {
-      get: 'NOTIFICATION_GET',
-      getOpts: {
-        getOnOnline: true,
-      },
-      getParser: () => ({
-        'V1 Alarm Type': 0,
-        'Notification Type': 'Emergency',
-      }),
       report: 'NOTIFICATION_REPORT',
       reportParser: report => {
         if (report && report['Notification Type'] === 'Emergency') {

--- a/drivers/NAS-RS01ZE/device.js
+++ b/drivers/NAS-RS01ZE/device.js
@@ -10,14 +10,6 @@ class KeyFob_RS01Z extends ZwaveDevice {
     this.registerCapability('measure_battery', 'BATTERY');
 
     this.registerCapability('alarm_emergency', 'NOTIFICATION', {
-      get: 'NOTIFICATION_GET',
-      getOpts: {
-        getOnOnline: true,
-      },
-      getParser: () => ({
-        'V1 Alarm Type': 0,
-        'Notification Type': 'Emergency',
-      }),
       report: 'NOTIFICATION_REPORT',
       reportParser: report => {
         if (report && report['Notification Type'] === 'Emergency') {


### PR DESCRIPTION
This PR is an alternative to #166 that removes `getOnOnline` for all `'NOTIFICATION'` capabilities (also the PIR v1).

As I explained in #166 before Homey 5.0.0 `getOnOnline` wouldn't do what you'd expect. Given that it was like that for a long time it seems safe to remove it everywhere.

I specifically removed it for the notification capabilities because it is usually the fallback for other capabilities and given its long history it COMMAND_CLASS_NOTIFICATION has some "interesting" behaviour.

There's also the option of completely removing `getOnOnline` but I'll leave that judgement call to you :)
