### PR TITLE
Add basic Homey SDK version test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "homey-zwavedriver": "^2.1.0"
   },
   "devDependencies": {
-		"eslint": "^6.8.0",
-		"eslint-config-athom": "^2.1.0"
+    "eslint": "^6.8.0",
+    "eslint-config-athom": "^2.1.0"
   },
   "scripts": {
     "run": "homeyConfig compose && athom project --run",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,0 +1,7 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const appJson = require('../app.json');
+
+test('uses Homey SDK v3', () => {
+  assert.strictEqual(appJson.sdk, 3);
+});


### PR DESCRIPTION
## Summary
- add simple node test verifying app.json declares Homey SDK v3
- wire npm test script to Node's built-in test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a41d50413883308d5efa63a0803860