### PR TITLE
Fix flow card placeholders for validation

### DIFF
--- a/app.json
+++ b/app.json
@@ -121,9 +121,9 @@
           "de": "Szene wurde aktiviert"
         },
         "titleFormatted": {
-          "en": "Button {{button}} {{scene}} is activated",
-          "nl": "Knop {{button}} {{scene}} is geactiveerd",
-          "de": "Taste {{button}} {{scene}} wurde aktiviert"
+          "en": "Button [[button]] [[scene]] is activated",
+          "nl": "Knop [[button]] [[scene]] is geactiveerd",
+          "de": "Taste [[button]] [[scene]] wurde aktiviert"
         },
         "hint": {
           "en": "This card will only get triggered if the button and scene match the state of the dropdown fields.",
@@ -245,9 +245,9 @@
           "de": "Ändern des Alarmstatus"
         },
         "titleFormatted": {
-          "en": "Change the alarm state",
-          "nl": "Verander de alarm toestand",
-          "de": "Ändern des Alarmstatus"
+          "en": "Change the alarm state to [[alarm_state]]",
+          "nl": "Verander de alarm toestand naar [[alarm_state]]",
+          "de": "Ändern des Alarmstatus zu [[alarm_state]]"
         },
         "hint": {
           "en": "Change the alarm state; sound or silence the alarm",
@@ -292,9 +292,9 @@
           "de": "Einstellen der Lautstärke der Sirene"
         },
         "titleFormatted": {
-          "en": "Set volume of siren",
-          "nl": "Zet het volume van de sirene",
-          "de": "Einstellen der Lautstärke der Sirene"
+          "en": "Set volume of siren to [[siren_volume]]",
+          "nl": "Zet het volume van de sirene op [[siren_volume]]",
+          "de": "Lautstärke der Sirene auf [[siren_volume]] einstellen"
         },
         "hint": {
           "en": "Set volume of siren.",
@@ -347,9 +347,9 @@
           "de": "Lautstärke der Türklingel einstellen."
         },
         "titleFormatted": {
-          "en": "Set volume of the doorbell",
-          "nl": "Zet het volume van de deurbel",
-          "de": "Lautstärke der Türklingel einstellen."
+          "en": "Set volume of the doorbell to [[doorbell_volume]]",
+          "nl": "Zet het volume van de deurbel op [[doorbell_volume]]",
+          "de": "Lautstärke der Türklingel auf [[doorbell_volume]] einstellen"
         },
         "hint": {
           "en": "Set volume of the doorbell.",
@@ -402,9 +402,9 @@
           "de": "Einstellen des Gerätemodus"
         },
         "titleFormatted": {
-          "en": "Set the device mode",
-          "nl": "Stel de apparaat modus in",
-          "de": "Einstellen des Gerätemodus"
+          "en": "Set the device mode to [[alarm_mode]]",
+          "nl": "Stel de apparaat modus in op [[alarm_mode]]",
+          "de": "Gerätemodus auf [[alarm_mode]] einstellen"
         },
         "hint": {
           "en": "Set the device mode; alarm or doorbell mode",
@@ -449,9 +449,9 @@
           "de": "Einstellen des Alarmtons"
         },
         "titleFormatted": {
-          "en": "Set the alarm tune",
-          "nl": "Stel de alarm melodie in",
-          "de": "Einstellen des Alarmtons"
+          "en": "Set the alarm tune to [[alarm_tune]]",
+          "nl": "Stel de alarm melodie in op [[alarm_tune]]",
+          "de": "Alarmmelodie auf [[alarm_tune]] einstellen"
         },
         "hint": {
           "en": "Choose the tune of the alarm sound",
@@ -560,9 +560,9 @@
           "de": "Einstellen der Türklingelmelodie"
         },
         "titleFormatted": {
-          "en": "Set the doorbell tune",
-          "nl": "Stel de deurbel melodie in",
-          "de": "Einstellen der Türklingelmelodie"
+          "en": "Set the doorbell tune to [[doorbell_tune]]",
+          "nl": "Stel de deurbel melodie in op [[doorbell_tune]]",
+          "de": "Türklingelmelodie auf [[doorbell_tune]] einstellen"
         },
         "hint": {
           "en": "Choose the tune of the doorbell sound",
@@ -671,9 +671,9 @@
           "de": "Touch-Steuerung LED einstellen"
         },
         "titleFormatted": {
-          "en": "Set Touch Switch LED",
-          "nl": "Stel Touch Switch LED in",
-          "de": "Touch-Steuerung LED einstellen"
+          "en": "Set Touch Switch LED to [[switch_LED_onoff]]",
+          "nl": "Stel Touch Switch LED in op [[switch_LED_onoff]]",
+          "de": "Touch-Steuerung LED auf [[switch_LED_onoff]] einstellen"
         },
         "hint": {
           "en": "Enable or disable the Touch Switch LED, lighting up when enabled",
@@ -718,9 +718,9 @@
           "de": "Touch-Steuerung LED einstellen"
         },
         "titleFormatted": {
-          "en": "Set Touch Switch LED",
-          "nl": "Stel Touch Switch LED in",
-          "de": "Touch-Steuerung LED einstellen"
+          "en": "Set Touch Switch LED to [[switch_LED_onoff]]",
+          "nl": "Stel Touch Switch LED in op [[switch_LED_onoff]]",
+          "de": "Touch-Steuerung LED auf [[switch_LED_onoff]] einstellen"
         },
         "hint": {
           "en": "Enable or disable the Touch Switch LED, lighting up when enabled",
@@ -765,9 +765,9 @@
           "de": "Touch-Steuerung LED einstellen"
         },
         "titleFormatted": {
-          "en": "Set Touch Switch LED",
-          "nl": "Stel Touch Switch LED in",
-          "de": "Touch-Steuerung LED einstellen"
+          "en": "Set Touch Switch LED to [[switch_LED_onoff]]",
+          "nl": "Stel Touch Switch LED in op [[switch_LED_onoff]]",
+          "de": "Touch-Steuerung LED auf [[switch_LED_onoff]] einstellen"
         },
         "hint": {
           "en": "Enable or disable the Touch Switch LED, lighting up when enabled",

--- a/drivers/NAS-AB01ZE/driver.flow.compose.json
+++ b/drivers/NAS-AB01ZE/driver.flow.compose.json
@@ -28,11 +28,11 @@
         "nl": "Verander de alarm toestand",
         "de": "Ändern des Alarmstatus"
       },
-      "titleFormatted": {
-        "en": "Change the alarm state",
-        "nl": "Verander de alarm toestand",
-        "de": "Ändern des Alarmstatus"
-      },
+        "titleFormatted": {
+          "en": "Change the alarm state to [[alarm_state]]",
+          "nl": "Verander de alarm toestand naar [[alarm_state]]",
+          "de": "Ändern des Alarmstatus zu [[alarm_state]]"
+        },
       "hint": {
         "en": "Change the alarm state; sound or silence the alarm",
         "nl": "Verander de alarm toestand; luiden of uitschakelen van het alarm",
@@ -71,9 +71,9 @@
         "de": "Einstellen der Lautstärke der Sirene"
       },
       "titleFormatted": {
-        "en": "Set volume of siren",
-        "nl": "Zet het volume van de sirene",
-        "de": "Einstellen der Lautstärke der Sirene"
+        "en": "Set volume of siren to [[siren_volume]]",
+        "nl": "Zet het volume van de sirene op [[siren_volume]]",
+        "de": "Lautstärke der Sirene auf [[siren_volume]] einstellen"
       },
       "hint": {
         "en": "Set volume of siren.",
@@ -121,9 +121,9 @@
         "de": "Lautstärke der Türklingel einstellen."
       },
       "titleFormatted": {
-        "en": "Set volume of the doorbell",
-        "nl": "Zet het volume van de deurbel",
-        "de": "Lautstärke der Türklingel einstellen."
+        "en": "Set volume of the doorbell to [[doorbell_volume]]",
+        "nl": "Zet het volume van de deurbel op [[doorbell_volume]]",
+        "de": "Lautstärke der Türklingel auf [[doorbell_volume]] einstellen"
       },
       "hint": {
         "en": "Set volume of the doorbell.",
@@ -171,9 +171,9 @@
         "de": "Einstellen des Gerätemodus"
       },
       "titleFormatted": {
-        "en": "Set the device mode",
-        "nl": "Stel de apparaat modus in",
-        "de": "Einstellen des Gerätemodus"
+        "en": "Set the device mode to [[alarm_mode]]",
+        "nl": "Stel de apparaat modus in op [[alarm_mode]]",
+        "de": "Gerätemodus auf [[alarm_mode]] einstellen"
       },
       "hint": {
         "en": "Set the device mode; alarm or doorbell mode",
@@ -213,9 +213,9 @@
         "de": "Einstellen des Alarmtons"
       },
       "titleFormatted": {
-        "en": "Set the alarm tune",
-        "nl": "Stel de alarm melodie in",
-        "de": "Einstellen des Alarmtons"
+        "en": "Set the alarm tune to [[alarm_tune]]",
+        "nl": "Stel de alarm melodie in op [[alarm_tune]]",
+        "de": "Alarmmelodie auf [[alarm_tune]] einstellen"
       },
       "hint": {
         "en": "Choose the tune of the alarm sound",
@@ -319,9 +319,9 @@
         "de": "Einstellen der Türklingelmelodie"
       },
       "titleFormatted": {
-        "en": "Set the doorbell tune",
-        "nl": "Stel de deurbel melodie in",
-        "de": "Einstellen der Türklingelmelodie"
+        "en": "Set the doorbell tune to [[doorbell_tune]]",
+        "nl": "Stel de deurbel melodie in op [[doorbell_tune]]",
+        "de": "Türklingelmelodie auf [[doorbell_tune]] einstellen"
       },
       "hint": {
         "en": "Choose the tune of the doorbell sound",

--- a/drivers/NAS-RC01ZE/driver.flow.compose.json
+++ b/drivers/NAS-RC01ZE/driver.flow.compose.json
@@ -7,11 +7,11 @@
         "nl": "Scene is geactiveerd",
         "de": "Szene wurde aktiviert"
       },
-    "titleFormatted": {
-      "en": "Button {{button}} {{scene}} is activated",
-      "nl": "Knop {{button}} {{scene}} is geactiveerd",
-      "de": "Taste {{button}} {{scene}} wurde aktiviert"
-    },
+  "titleFormatted": {
+    "en": "Button [[button]] [[scene]] is activated",
+    "nl": "Knop [[button]] [[scene]] is geactiveerd",
+    "de": "Taste [[button]] [[scene]] wurde aktiviert"
+  },
       "hint": {
         "en": "This card will only get triggered if the button and scene match the state of the dropdown fields.",
         "nl": "Deze kaart wordt alleen geactiveerd wanneer de knop en scene overeenkomen met de toestand van de gekozen opties.",

--- a/drivers/NAS-SC01ZE/driver.flow.compose.json
+++ b/drivers/NAS-SC01ZE/driver.flow.compose.json
@@ -7,11 +7,11 @@
         "nl": "Stel Touch Switch LED in",
         "de": "Touch-Steuerung LED einstellen"
       },
-      "titleFormatted": {
-        "en": "Set Touch Switch LED",
-        "nl": "Stel Touch Switch LED in",
-        "de": "Touch-Steuerung LED einstellen"
-      },
+        "titleFormatted": {
+          "en": "Set Touch Switch LED to [[switch_LED_onoff]]",
+          "nl": "Stel Touch Switch LED in op [[switch_LED_onoff]]",
+          "de": "Touch-Steuerung LED auf [[switch_LED_onoff]] einstellen"
+        },
       "hint": {
         "en": "Enable or disable the Touch Switch LED, lighting up when enabled",
         "nl": "In of uitschakelen van de Touch Switch LED, oplichtend wanneer ingeschakeld",

--- a/drivers/NAS-SC02ZE/driver.flow.compose.json
+++ b/drivers/NAS-SC02ZE/driver.flow.compose.json
@@ -7,11 +7,11 @@
         "nl": "Stel Touch Switch LED in",
         "de": "Touch-Steuerung LED einstellen"
       },
-      "titleFormatted": {
-        "en": "Set Touch Switch LED",
-        "nl": "Stel Touch Switch LED in",
-        "de": "Touch-Steuerung LED einstellen"
-      },
+        "titleFormatted": {
+          "en": "Set Touch Switch LED to [[switch_LED_onoff]]",
+          "nl": "Stel Touch Switch LED in op [[switch_LED_onoff]]",
+          "de": "Touch-Steuerung LED auf [[switch_LED_onoff]] einstellen"
+        },
       "hint": {
         "en": "Enable or disable the Touch Switch LED, lighting up when enabled",
         "nl": "In of uitschakelen van de Touch Switch LED, oplichtend wanneer ingeschakeld",

--- a/drivers/NAS-SC03ZE/driver.flow.compose.json
+++ b/drivers/NAS-SC03ZE/driver.flow.compose.json
@@ -7,11 +7,11 @@
         "nl": "Stel Touch Switch LED in",
         "de": "Touch-Steuerung LED einstellen"
       },
-      "titleFormatted": {
-        "en": "Set Touch Switch LED",
-        "nl": "Stel Touch Switch LED in",
-        "de": "Touch-Steuerung LED einstellen"
-      },
+        "titleFormatted": {
+          "en": "Set Touch Switch LED to [[switch_LED_onoff]]",
+          "nl": "Stel Touch Switch LED in op [[switch_LED_onoff]]",
+          "de": "Touch-Steuerung LED auf [[switch_LED_onoff]] einstellen"
+        },
       "hint": {
         "en": "Enable or disable the Touch Switch LED, lighting up when enabled",
         "nl": "In of uitschakelen van de Touch Switch LED, oplichtend wanneer ingeschakeld",


### PR DESCRIPTION
## Summary
- use [[arg]] placeholders in RC_scene trigger title
- add missing argument placeholders to various AB01ZE action cards
- include LED state placeholders for SC01ZE/SC02ZE/SC03ZE actions

## Testing
- `homey app validate`


------
https://chatgpt.com/codex/tasks/task_e_68a43198a9788330ad80adbc71b5a99d