### PR TITLE
Fix Z-Wave capability initialization and meter parser issues

### DIFF
--- a/drivers/NAS-PD07ZE/device.js
+++ b/drivers/NAS-PD07ZE/device.js
@@ -14,10 +14,22 @@ class MultiSensor_PD07Z extends ZwaveDevice {
 
     // register device capabilities
     this.registerCapability('alarm_motion', 'NOTIFICATION');
-	this.registerCapability('alarm_tamper', 'NOTIFICATION');
-    this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL');
-	this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL');
-	this.registerCapability('measure_humidity', 'SENSOR_MULTILEVEL');
+        this.registerCapability('alarm_tamper', 'NOTIFICATION');
+    this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL', {
+      getOpts: {
+        getOnStart: false,
+      },
+    });
+        this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL', {
+      getOpts: {
+        getOnStart: false,
+      },
+    });
+        this.registerCapability('measure_humidity', 'SENSOR_MULTILEVEL', {
+      getOpts: {
+        getOnStart: false,
+      },
+    });
     this.registerCapability('measure_battery', 'BATTERY');
   }
 }

--- a/drivers/NAS-WR02ZE/device.js
+++ b/drivers/NAS-WR02ZE/device.js
@@ -15,12 +15,13 @@ class Wallplug_WR02Z extends ZwaveDevice {
     // register capabilities for this device
     this.registerCapability('onoff', 'SWITCH_BINARY');
 
-		this.registerCapability('measure_power', 'METER', {
+        this.registerCapability('measure_power', 'METER', {
             getParserV4: () => ({
-                'Sensor Type': 'Electric meter',
-                'Properties1': {
-                    'Scale': 2,
-                }
+                Properties1: {
+                    'Rate Type': 'Import',
+                    Scale: 2,
+                },
+                'Scale 2': 0,
             }),
             reportParserV4: report => {
                 if (report.hasOwnProperty('Properties2') &&
@@ -36,10 +37,11 @@ class Wallplug_WR02Z extends ZwaveDevice {
 
         this.registerCapability('meter_power', 'METER', {
             getParserV4: () => ({
-                'Sensor Type': 'Electric meter',
-                'Properties1': {
-                    'Scale': 0,
-                }
+                Properties1: {
+                    'Rate Type': 'Import',
+                    Scale: 0,
+                },
+                'Scale 2': 0,
             }),
             reportParserV4: report => {
                 if (report.hasOwnProperty('Properties2') &&
@@ -60,10 +62,11 @@ class Wallplug_WR02Z extends ZwaveDevice {
 
         this.registerCapability('measure_voltage', 'METER', {
             getParserV4: () => ({
-                'Sensor Type': 'Electric meter',
-                'Properties1': {
-                    'Scale': 4,
-                }
+                Properties1: {
+                    'Rate Type': 'Import',
+                    Scale: 4,
+                },
+                'Scale 2': 0,
             }),
             reportParserV4: report => {
                 if (report.hasOwnProperty('Properties2') &&
@@ -79,10 +82,11 @@ class Wallplug_WR02Z extends ZwaveDevice {
 
         this.registerCapability('measure_current', 'METER', {
             getParserV4: () => ({
-                'Sensor Type': 'Electric meter',
-                'Properties1': {
-                    'Scale': 5,
-                }
+                Properties1: {
+                    'Rate Type': 'Import',
+                    Scale: 5,
+                },
+                'Scale 2': 0,
             }),
             reportParserV4: report => {
                 if (report.hasOwnProperty('Properties2') &&
@@ -104,7 +108,7 @@ class Wallplug_WR02Z extends ZwaveDevice {
 
     const actionWR02Z_reset_meter = this.homey.flow
       .getActionCard('WR02Z_reset_meter')
-      .registerRunListener(WR02_reset_meter_run_listener);		
+      .registerRunListener(WR02Z_reset_meter_run_listener);
   }
 }
 module.exports = Wallplug_WR02Z;


### PR DESCRIPTION
## Summary
- disable startup polls for battery-powered multi-sensor
- correct meter capability parsers and flow run listener for WR02Z plug

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a43c24b9148330b5fb675d148c62ee