### PR TITLE
feat: detect sensor capabilities for NAS-PD01ZE

### DIFF
--- a/drivers/NAS-PD01ZE/device.js
+++ b/drivers/NAS-PD01ZE/device.js
@@ -12,11 +12,59 @@ class MultiSensor_PD01Z extends ZwaveDevice {
     // print the node's info to the console
     // this.printNode();
 
-    // register device capabilities
-    this.registerCapability('alarm_motion', 'NOTIFICATION');
-    this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL');
-	this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL');
+    // always available capability
     this.registerCapability('measure_battery', 'BATTERY');
+
+    const commandClasses = this.node.CommandClass || {};
+
+    // motion alarm capability
+    if (
+      commandClasses.COMMAND_CLASS_NOTIFICATION
+      || commandClasses.COMMAND_CLASS_SENSOR_BINARY
+    ) {
+      if (!this.hasCapability('alarm_motion')) {
+        await this.addCapability('alarm_motion');
+      }
+      const cc = commandClasses.COMMAND_CLASS_NOTIFICATION
+        ? 'NOTIFICATION'
+        : 'SENSOR_BINARY';
+      this.registerCapability('alarm_motion', cc);
+    }
+
+    // multilevel sensor capabilities
+    const multilevel = commandClasses.COMMAND_CLASS_SENSOR_MULTILEVEL;
+    if (multilevel) {
+      let supported = [];
+
+      if (typeof multilevel.SUPPORTED_GET === 'function') {
+        try {
+          const result = await multilevel.SUPPORTED_GET();
+          if (Array.isArray(result?.['Sensor Type'])) {
+            supported = result['Sensor Type'];
+          } else if (Array.isArray(result?.['Sensor Type Bit Mask'])) {
+            supported = result['Sensor Type Bit Mask'];
+          } else if (Array.isArray(result?.supportedSensorTypes)) {
+            supported = result.supportedSensorTypes;
+          }
+        } catch (err) {
+          this.error('Failed to read supported sensor types', err);
+        }
+      } else if (Array.isArray(multilevel.supportedSensorTypes)) {
+        supported = multilevel.supportedSensorTypes;
+      }
+
+      const hasTemperature = supported.includes('Temperature') || supported.includes(1);
+      if (hasTemperature && !this.hasCapability('measure_temperature')) {
+        await this.addCapability('measure_temperature');
+        this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL');
+      }
+
+      const hasLuminance = supported.includes('Luminance') || supported.includes(3);
+      if (hasLuminance && !this.hasCapability('measure_luminance')) {
+        await this.addCapability('measure_luminance');
+        this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL');
+      }
+    }
   }
 }
 module.exports = MultiSensor_PD01Z;

--- a/drivers/NAS-PD01ZE/driver.compose.json
+++ b/drivers/NAS-PD01ZE/driver.compose.json
@@ -157,8 +157,6 @@
     ]
   },
   "capabilities": [
-    "alarm_motion",
-    "measure_luminance",
     "measure_battery"
   ],
   "images": {


### PR DESCRIPTION
## Summary
- detect available NAS-PD01ZE sensors during pairing
- keep driver capabilities minimal by default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6f8f1d904833086c7872075d2e61d