### PR TITLE
feat: detect sensors for NAS-PD0xZE drivers

### DIFF
--- a/drivers/NAS-PD01ZE/device.js
+++ b/drivers/NAS-PD01ZE/device.js
@@ -12,11 +12,75 @@ class MultiSensor_PD01Z extends ZwaveDevice {
     // print the node's info to the console
     // this.printNode();
 
-    // register device capabilities
-    this.registerCapability('alarm_motion', 'NOTIFICATION');
-    this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL');
-	this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL');
+    // always available capability
     this.registerCapability('measure_battery', 'BATTERY');
+
+    const commandClasses = this.node.CommandClass || {};
+
+    // motion and tamper alarm capabilities
+    if (
+      commandClasses.COMMAND_CLASS_NOTIFICATION
+      || commandClasses.COMMAND_CLASS_SENSOR_BINARY
+    ) {
+      if (!this.hasCapability('alarm_motion')) {
+        await this.addCapability('alarm_motion');
+      }
+      const cc = commandClasses.COMMAND_CLASS_NOTIFICATION
+        ? 'NOTIFICATION'
+        : 'SENSOR_BINARY';
+      this.registerCapability('alarm_motion', cc);
+
+      if (commandClasses.COMMAND_CLASS_NOTIFICATION) {
+        if (!this.hasCapability('alarm_tamper')) {
+          await this.addCapability('alarm_tamper');
+        }
+        this.registerCapability('alarm_tamper', 'NOTIFICATION');
+      }
+    }
+
+    // multilevel sensor capabilities
+    const multilevel = commandClasses.COMMAND_CLASS_SENSOR_MULTILEVEL;
+    if (multilevel) {
+      let supported = [];
+
+      if (typeof multilevel.SUPPORTED_GET === 'function') {
+        try {
+          const result = await multilevel.SUPPORTED_GET();
+          if (Array.isArray(result?.['Sensor Type'])) {
+            supported = result['Sensor Type'];
+          } else if (Array.isArray(result?.['Sensor Type Bit Mask'])) {
+            supported = result['Sensor Type Bit Mask'];
+          } else if (Array.isArray(result?.supportedSensorTypes)) {
+            supported = result.supportedSensorTypes;
+          }
+        } catch (err) {
+          this.error('Failed to read supported sensor types', err);
+        }
+      } else if (Array.isArray(multilevel.supportedSensorTypes)) {
+        supported = multilevel.supportedSensorTypes;
+      }
+
+      const hasTemperature = supported.includes('Temperature') || supported.includes(1);
+      if (hasTemperature && !this.hasCapability('measure_temperature')) {
+        await this.addCapability('measure_temperature');
+        this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL');
+      }
+
+      const hasLuminance = supported.includes('Luminance') || supported.includes(3);
+      if (hasLuminance && !this.hasCapability('measure_luminance')) {
+        await this.addCapability('measure_luminance');
+        this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL');
+      }
+
+      const hasHumidity =
+        supported.includes('Relative humidity')
+        || supported.includes('Humidity')
+        || supported.includes(5);
+      if (hasHumidity && !this.hasCapability('measure_humidity')) {
+        await this.addCapability('measure_humidity');
+        this.registerCapability('measure_humidity', 'SENSOR_MULTILEVEL');
+      }
+    }
   }
 }
 module.exports = MultiSensor_PD01Z;

--- a/drivers/NAS-PD01ZE/driver.compose.json
+++ b/drivers/NAS-PD01ZE/driver.compose.json
@@ -157,8 +157,6 @@
     ]
   },
   "capabilities": [
-    "alarm_motion",
-    "measure_luminance",
     "measure_battery"
   ],
   "images": {

--- a/drivers/NAS-PD02ZE/device.js
+++ b/drivers/NAS-PD02ZE/device.js
@@ -12,11 +12,75 @@ class MultiSensor_PD02Z extends ZwaveDevice {
     // print the node's info to the console
     // this.printNode();
 
-    // register device capabilities
-    this.registerCapability('alarm_motion', 'NOTIFICATION');
-    this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL');
-	this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL');
+    // always available capability
     this.registerCapability('measure_battery', 'BATTERY');
+
+    const commandClasses = this.node.CommandClass || {};
+
+    // motion and tamper alarm capabilities
+    if (
+      commandClasses.COMMAND_CLASS_NOTIFICATION
+      || commandClasses.COMMAND_CLASS_SENSOR_BINARY
+    ) {
+      if (!this.hasCapability('alarm_motion')) {
+        await this.addCapability('alarm_motion');
+      }
+      const cc = commandClasses.COMMAND_CLASS_NOTIFICATION
+        ? 'NOTIFICATION'
+        : 'SENSOR_BINARY';
+      this.registerCapability('alarm_motion', cc);
+
+      if (commandClasses.COMMAND_CLASS_NOTIFICATION) {
+        if (!this.hasCapability('alarm_tamper')) {
+          await this.addCapability('alarm_tamper');
+        }
+        this.registerCapability('alarm_tamper', 'NOTIFICATION');
+      }
+    }
+
+    // multilevel sensor capabilities
+    const multilevel = commandClasses.COMMAND_CLASS_SENSOR_MULTILEVEL;
+    if (multilevel) {
+      let supported = [];
+
+      if (typeof multilevel.SUPPORTED_GET === 'function') {
+        try {
+          const result = await multilevel.SUPPORTED_GET();
+          if (Array.isArray(result?.['Sensor Type'])) {
+            supported = result['Sensor Type'];
+          } else if (Array.isArray(result?.['Sensor Type Bit Mask'])) {
+            supported = result['Sensor Type Bit Mask'];
+          } else if (Array.isArray(result?.supportedSensorTypes)) {
+            supported = result.supportedSensorTypes;
+          }
+        } catch (err) {
+          this.error('Failed to read supported sensor types', err);
+        }
+      } else if (Array.isArray(multilevel.supportedSensorTypes)) {
+        supported = multilevel.supportedSensorTypes;
+      }
+
+      const hasTemperature = supported.includes('Temperature') || supported.includes(1);
+      if (hasTemperature && !this.hasCapability('measure_temperature')) {
+        await this.addCapability('measure_temperature');
+        this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL');
+      }
+
+      const hasLuminance = supported.includes('Luminance') || supported.includes(3);
+      if (hasLuminance && !this.hasCapability('measure_luminance')) {
+        await this.addCapability('measure_luminance');
+        this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL');
+      }
+
+      const hasHumidity =
+        supported.includes('Relative humidity')
+        || supported.includes('Humidity')
+        || supported.includes(5);
+      if (hasHumidity && !this.hasCapability('measure_humidity')) {
+        await this.addCapability('measure_humidity');
+        this.registerCapability('measure_humidity', 'SENSOR_MULTILEVEL');
+      }
+    }
   }
 }
 module.exports = MultiSensor_PD02Z;

--- a/drivers/NAS-PD02ZE/driver.compose.json
+++ b/drivers/NAS-PD02ZE/driver.compose.json
@@ -154,9 +154,6 @@
     ]
   },
   "capabilities": [
-    "alarm_motion",
-    "measure_temperature",
-    "measure_luminance",
     "measure_battery"
   ],
   "images": {

--- a/drivers/NAS-PD03ZE/device.js
+++ b/drivers/NAS-PD03ZE/device.js
@@ -12,11 +12,75 @@ class MultiSensor_PD03Z extends ZwaveDevice {
     // print the node's info to the console
     // this.printNode();
 
-    // register device capabilities
-    this.registerCapability('alarm_motion', 'NOTIFICATION');
-    this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL');
-	this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL');
+    // always available capability
     this.registerCapability('measure_battery', 'BATTERY');
+
+    const commandClasses = this.node.CommandClass || {};
+
+    // motion and tamper alarm capabilities
+    if (
+      commandClasses.COMMAND_CLASS_NOTIFICATION
+      || commandClasses.COMMAND_CLASS_SENSOR_BINARY
+    ) {
+      if (!this.hasCapability('alarm_motion')) {
+        await this.addCapability('alarm_motion');
+      }
+      const cc = commandClasses.COMMAND_CLASS_NOTIFICATION
+        ? 'NOTIFICATION'
+        : 'SENSOR_BINARY';
+      this.registerCapability('alarm_motion', cc);
+
+      if (commandClasses.COMMAND_CLASS_NOTIFICATION) {
+        if (!this.hasCapability('alarm_tamper')) {
+          await this.addCapability('alarm_tamper');
+        }
+        this.registerCapability('alarm_tamper', 'NOTIFICATION');
+      }
+    }
+
+    // multilevel sensor capabilities
+    const multilevel = commandClasses.COMMAND_CLASS_SENSOR_MULTILEVEL;
+    if (multilevel) {
+      let supported = [];
+
+      if (typeof multilevel.SUPPORTED_GET === 'function') {
+        try {
+          const result = await multilevel.SUPPORTED_GET();
+          if (Array.isArray(result?.['Sensor Type'])) {
+            supported = result['Sensor Type'];
+          } else if (Array.isArray(result?.['Sensor Type Bit Mask'])) {
+            supported = result['Sensor Type Bit Mask'];
+          } else if (Array.isArray(result?.supportedSensorTypes)) {
+            supported = result.supportedSensorTypes;
+          }
+        } catch (err) {
+          this.error('Failed to read supported sensor types', err);
+        }
+      } else if (Array.isArray(multilevel.supportedSensorTypes)) {
+        supported = multilevel.supportedSensorTypes;
+      }
+
+      const hasTemperature = supported.includes('Temperature') || supported.includes(1);
+      if (hasTemperature && !this.hasCapability('measure_temperature')) {
+        await this.addCapability('measure_temperature');
+        this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL');
+      }
+
+      const hasLuminance = supported.includes('Luminance') || supported.includes(3);
+      if (hasLuminance && !this.hasCapability('measure_luminance')) {
+        await this.addCapability('measure_luminance');
+        this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL');
+      }
+
+      const hasHumidity =
+        supported.includes('Relative humidity')
+        || supported.includes('Humidity')
+        || supported.includes(5);
+      if (hasHumidity && !this.hasCapability('measure_humidity')) {
+        await this.addCapability('measure_humidity');
+        this.registerCapability('measure_humidity', 'SENSOR_MULTILEVEL');
+      }
+    }
   }
 }
 module.exports = MultiSensor_PD03Z;

--- a/drivers/NAS-PD03ZE/driver.compose.json
+++ b/drivers/NAS-PD03ZE/driver.compose.json
@@ -149,9 +149,6 @@
     ]
   },
   "capabilities": [
-    "alarm_motion",
-    "measure_temperature",
-    "measure_luminance",
     "measure_battery"
   ],
   "images": {

--- a/drivers/NAS-PD07ZE/device.js
+++ b/drivers/NAS-PD07ZE/device.js
@@ -12,25 +12,87 @@ class MultiSensor_PD07Z extends ZwaveDevice {
     // print the node's info to the console
     // this.printNode();
 
-    // register device capabilities
-    this.registerCapability('alarm_motion', 'NOTIFICATION');
-        this.registerCapability('alarm_tamper', 'NOTIFICATION');
-    this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL', {
-      getOpts: {
-        getOnStart: false,
-      },
-    });
-        this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL', {
-      getOpts: {
-        getOnStart: false,
-      },
-    });
-        this.registerCapability('measure_humidity', 'SENSOR_MULTILEVEL', {
-      getOpts: {
-        getOnStart: false,
-      },
-    });
+    // always available capability
     this.registerCapability('measure_battery', 'BATTERY');
+
+    const commandClasses = this.node.CommandClass || {};
+
+    // notification based capabilities
+    if (
+      commandClasses.COMMAND_CLASS_NOTIFICATION
+      || commandClasses.COMMAND_CLASS_SENSOR_BINARY
+    ) {
+      if (!this.hasCapability('alarm_motion')) {
+        await this.addCapability('alarm_motion');
+      }
+      const cc = commandClasses.COMMAND_CLASS_NOTIFICATION
+        ? 'NOTIFICATION'
+        : 'SENSOR_BINARY';
+      this.registerCapability('alarm_motion', cc);
+
+      if (commandClasses.COMMAND_CLASS_NOTIFICATION) {
+        if (!this.hasCapability('alarm_tamper')) {
+          await this.addCapability('alarm_tamper');
+        }
+        this.registerCapability('alarm_tamper', 'NOTIFICATION');
+      }
+    }
+
+    // multilevel sensor capabilities
+    const multilevel = commandClasses.COMMAND_CLASS_SENSOR_MULTILEVEL;
+    if (multilevel) {
+      let supported = [];
+
+      if (typeof multilevel.SUPPORTED_GET === 'function') {
+        try {
+          const result = await multilevel.SUPPORTED_GET();
+          if (Array.isArray(result?.['Sensor Type'])) {
+            supported = result['Sensor Type'];
+          } else if (Array.isArray(result?.['Sensor Type Bit Mask'])) {
+            supported = result['Sensor Type Bit Mask'];
+          } else if (Array.isArray(result?.supportedSensorTypes)) {
+            supported = result.supportedSensorTypes;
+          }
+        } catch (err) {
+          this.error('Failed to read supported sensor types', err);
+        }
+      } else if (Array.isArray(multilevel.supportedSensorTypes)) {
+        supported = multilevel.supportedSensorTypes;
+      }
+
+      const hasTemperature = supported.includes('Temperature') || supported.includes(1);
+      if (hasTemperature && !this.hasCapability('measure_temperature')) {
+        await this.addCapability('measure_temperature');
+        this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL', {
+          getOpts: {
+            getOnStart: false,
+          },
+        });
+      }
+
+      const hasLuminance = supported.includes('Luminance') || supported.includes(3);
+      if (hasLuminance && !this.hasCapability('measure_luminance')) {
+        await this.addCapability('measure_luminance');
+        this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL', {
+          getOpts: {
+            getOnStart: false,
+          },
+        });
+      }
+
+      const hasHumidity =
+        supported.includes('Relative humidity')
+        || supported.includes('Humidity')
+        || supported.includes(5);
+      if (hasHumidity && !this.hasCapability('measure_humidity')) {
+        await this.addCapability('measure_humidity');
+        this.registerCapability('measure_humidity', 'SENSOR_MULTILEVEL', {
+          getOpts: {
+            getOnStart: false,
+          },
+        });
+      }
+    }
   }
 }
 module.exports = MultiSensor_PD07Z;

--- a/drivers/NAS-PD07ZE/driver.compose.json
+++ b/drivers/NAS-PD07ZE/driver.compose.json
@@ -106,11 +106,6 @@
     ]
   },
   "capabilities": [
-    "alarm_motion",
-    "alarm_tamper",
-    "measure_temperature",
-    "measure_luminance",
-    "measure_humidity",
     "measure_battery"
   ],
   "images": {


### PR DESCRIPTION
## Summary
- detect capabilities for NAS-PD01ZE, NAS-PD02ZE, NAS-PD03ZE, and NAS-PD07ZE during pairing
- default to battery capability for these drivers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6f8f1d904833086c7872075d2e61d