### PR TITLE
feat: detect tamper and humidity for PIR sensors

### DIFF
--- a/drivers/NAS-PD01ZE/device.js
+++ b/drivers/NAS-PD01ZE/device.js
@@ -29,6 +29,13 @@ class MultiSensor_PD01Z extends ZwaveDevice {
         ? 'NOTIFICATION'
         : 'SENSOR_BINARY';
       this.registerCapability('alarm_motion', cc);
+
+      if (commandClasses.COMMAND_CLASS_NOTIFICATION) {
+        if (!this.hasCapability('alarm_tamper')) {
+          await this.addCapability('alarm_tamper');
+        }
+        this.registerCapability('alarm_tamper', 'NOTIFICATION');
+      }
     }
 
     // multilevel sensor capabilities
@@ -63,6 +70,15 @@ class MultiSensor_PD01Z extends ZwaveDevice {
       if (hasLuminance && !this.hasCapability('measure_luminance')) {
         await this.addCapability('measure_luminance');
         this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL');
+      }
+
+      const hasHumidity =
+        supported.includes('Relative humidity')
+        || supported.includes('Humidity')
+        || supported.includes(5);
+      if (hasHumidity && !this.hasCapability('measure_humidity')) {
+        await this.addCapability('measure_humidity');
+        this.registerCapability('measure_humidity', 'SENSOR_MULTILEVEL');
       }
     }
   }

--- a/drivers/NAS-PD02ZE/device.js
+++ b/drivers/NAS-PD02ZE/device.js
@@ -29,6 +29,13 @@ class MultiSensor_PD02Z extends ZwaveDevice {
         ? 'NOTIFICATION'
         : 'SENSOR_BINARY';
       this.registerCapability('alarm_motion', cc);
+
+      if (commandClasses.COMMAND_CLASS_NOTIFICATION) {
+        if (!this.hasCapability('alarm_tamper')) {
+          await this.addCapability('alarm_tamper');
+        }
+        this.registerCapability('alarm_tamper', 'NOTIFICATION');
+      }
     }
 
     // multilevel sensor capabilities
@@ -63,6 +70,15 @@ class MultiSensor_PD02Z extends ZwaveDevice {
       if (hasLuminance && !this.hasCapability('measure_luminance')) {
         await this.addCapability('measure_luminance');
         this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL');
+      }
+
+      const hasHumidity =
+        supported.includes('Relative humidity')
+        || supported.includes('Humidity')
+        || supported.includes(5);
+      if (hasHumidity && !this.hasCapability('measure_humidity')) {
+        await this.addCapability('measure_humidity');
+        this.registerCapability('measure_humidity', 'SENSOR_MULTILEVEL');
       }
     }
   }

--- a/drivers/NAS-PD03ZE/device.js
+++ b/drivers/NAS-PD03ZE/device.js
@@ -29,6 +29,13 @@ class MultiSensor_PD03Z extends ZwaveDevice {
         ? 'NOTIFICATION'
         : 'SENSOR_BINARY';
       this.registerCapability('alarm_motion', cc);
+
+      if (commandClasses.COMMAND_CLASS_NOTIFICATION) {
+        if (!this.hasCapability('alarm_tamper')) {
+          await this.addCapability('alarm_tamper');
+        }
+        this.registerCapability('alarm_tamper', 'NOTIFICATION');
+      }
     }
 
     // multilevel sensor capabilities
@@ -63,6 +70,15 @@ class MultiSensor_PD03Z extends ZwaveDevice {
       if (hasLuminance && !this.hasCapability('measure_luminance')) {
         await this.addCapability('measure_luminance');
         this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL');
+      }
+
+      const hasHumidity =
+        supported.includes('Relative humidity')
+        || supported.includes('Humidity')
+        || supported.includes(5);
+      if (hasHumidity && !this.hasCapability('measure_humidity')) {
+        await this.addCapability('measure_humidity');
+        this.registerCapability('measure_humidity', 'SENSOR_MULTILEVEL');
       }
     }
   }


### PR DESCRIPTION
## Summary
- auto-detect `alarm_tamper` on NAS-PD01ZE/02ZE/03ZE when notifications are available
- auto-detect `measure_humidity` if multilevel sensor reports humidity support

## Testing
- `npm test`
- `npx eslint drivers/NAS-PD01ZE/device.js drivers/NAS-PD02ZE/device.js drivers/NAS-PD03ZE/device.js` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68a7053864148330b20f6d62a6ff7041