### PR TITLE
Fix RC_scene trigger tokens

### DIFF
--- a/drivers/NAS-RC01ZE/device.js
+++ b/drivers/NAS-RC01ZE/device.js
@@ -77,7 +77,8 @@ class KeyFob_RC01Z extends ZwaveDevice {
           PreviousSequenceNo = rawReport['Sequence Number'];
           this.log('Triggering sequence:', PreviousSequenceNo, 'remoteValue', remoteValue);
           // Trigger the trigger card with 2 dropdown options
-          triggerRC_scene.trigger(this, triggerRC_scene.getArgumentValues, remoteValue);
+          // Use remoteValue for tokens and state
+          triggerRC_scene.trigger(this, remoteValue, remoteValue);
         }
       }
     });


### PR DESCRIPTION
## Summary
- fix RC_scene trigger by passing token object instead of function
- document that remoteValue is used for both tokens and state
- verify other driver triggers already pass token objects

## Testing
- `npm test`
- `npx eslint drivers/NAS-RC01ZE/device.js` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68a947fab7e48330b155ade3b5e7540e