### PR TITLE
Fix dynamic capability registration for PIR sensors

### DIFF
--- a/drivers/NAS-PD01ZE/device.js
+++ b/drivers/NAS-PD01ZE/device.js
@@ -61,14 +61,18 @@ class MultiSensor_PD01Z extends ZwaveDevice {
       }
 
       const hasTemperature = supported.includes('Temperature') || supported.includes(1);
-      if (hasTemperature && !this.hasCapability('measure_temperature')) {
-        await this.addCapability('measure_temperature');
+      if (hasTemperature) {
+        if (!this.hasCapability('measure_temperature')) {
+          await this.addCapability('measure_temperature');
+        }
         this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL');
       }
 
       const hasLuminance = supported.includes('Luminance') || supported.includes(3);
-      if (hasLuminance && !this.hasCapability('measure_luminance')) {
-        await this.addCapability('measure_luminance');
+      if (hasLuminance) {
+        if (!this.hasCapability('measure_luminance')) {
+          await this.addCapability('measure_luminance');
+        }
         this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL');
       }
 
@@ -76,8 +80,10 @@ class MultiSensor_PD01Z extends ZwaveDevice {
         supported.includes('Relative humidity')
         || supported.includes('Humidity')
         || supported.includes(5);
-      if (hasHumidity && !this.hasCapability('measure_humidity')) {
-        await this.addCapability('measure_humidity');
+      if (hasHumidity) {
+        if (!this.hasCapability('measure_humidity')) {
+          await this.addCapability('measure_humidity');
+        }
         this.registerCapability('measure_humidity', 'SENSOR_MULTILEVEL');
       }
     }

--- a/drivers/NAS-PD02ZE/device.js
+++ b/drivers/NAS-PD02ZE/device.js
@@ -61,14 +61,18 @@ class MultiSensor_PD02Z extends ZwaveDevice {
       }
 
       const hasTemperature = supported.includes('Temperature') || supported.includes(1);
-      if (hasTemperature && !this.hasCapability('measure_temperature')) {
-        await this.addCapability('measure_temperature');
+      if (hasTemperature) {
+        if (!this.hasCapability('measure_temperature')) {
+          await this.addCapability('measure_temperature');
+        }
         this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL');
       }
 
       const hasLuminance = supported.includes('Luminance') || supported.includes(3);
-      if (hasLuminance && !this.hasCapability('measure_luminance')) {
-        await this.addCapability('measure_luminance');
+      if (hasLuminance) {
+        if (!this.hasCapability('measure_luminance')) {
+          await this.addCapability('measure_luminance');
+        }
         this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL');
       }
 
@@ -76,8 +80,10 @@ class MultiSensor_PD02Z extends ZwaveDevice {
         supported.includes('Relative humidity')
         || supported.includes('Humidity')
         || supported.includes(5);
-      if (hasHumidity && !this.hasCapability('measure_humidity')) {
-        await this.addCapability('measure_humidity');
+      if (hasHumidity) {
+        if (!this.hasCapability('measure_humidity')) {
+          await this.addCapability('measure_humidity');
+        }
         this.registerCapability('measure_humidity', 'SENSOR_MULTILEVEL');
       }
     }

--- a/drivers/NAS-PD03ZE/device.js
+++ b/drivers/NAS-PD03ZE/device.js
@@ -61,14 +61,18 @@ class MultiSensor_PD03Z extends ZwaveDevice {
       }
 
       const hasTemperature = supported.includes('Temperature') || supported.includes(1);
-      if (hasTemperature && !this.hasCapability('measure_temperature')) {
-        await this.addCapability('measure_temperature');
+      if (hasTemperature) {
+        if (!this.hasCapability('measure_temperature')) {
+          await this.addCapability('measure_temperature');
+        }
         this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL');
       }
 
       const hasLuminance = supported.includes('Luminance') || supported.includes(3);
-      if (hasLuminance && !this.hasCapability('measure_luminance')) {
-        await this.addCapability('measure_luminance');
+      if (hasLuminance) {
+        if (!this.hasCapability('measure_luminance')) {
+          await this.addCapability('measure_luminance');
+        }
         this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL');
       }
 
@@ -76,8 +80,10 @@ class MultiSensor_PD03Z extends ZwaveDevice {
         supported.includes('Relative humidity')
         || supported.includes('Humidity')
         || supported.includes(5);
-      if (hasHumidity && !this.hasCapability('measure_humidity')) {
-        await this.addCapability('measure_humidity');
+      if (hasHumidity) {
+        if (!this.hasCapability('measure_humidity')) {
+          await this.addCapability('measure_humidity');
+        }
         this.registerCapability('measure_humidity', 'SENSOR_MULTILEVEL');
       }
     }

--- a/drivers/NAS-PD07ZE/device.js
+++ b/drivers/NAS-PD07ZE/device.js
@@ -61,8 +61,10 @@ class MultiSensor_PD07Z extends ZwaveDevice {
       }
 
       const hasTemperature = supported.includes('Temperature') || supported.includes(1);
-      if (hasTemperature && !this.hasCapability('measure_temperature')) {
-        await this.addCapability('measure_temperature');
+      if (hasTemperature) {
+        if (!this.hasCapability('measure_temperature')) {
+          await this.addCapability('measure_temperature');
+        }
         this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL', {
           getOpts: {
             getOnStart: false,
@@ -71,8 +73,10 @@ class MultiSensor_PD07Z extends ZwaveDevice {
       }
 
       const hasLuminance = supported.includes('Luminance') || supported.includes(3);
-      if (hasLuminance && !this.hasCapability('measure_luminance')) {
-        await this.addCapability('measure_luminance');
+      if (hasLuminance) {
+        if (!this.hasCapability('measure_luminance')) {
+          await this.addCapability('measure_luminance');
+        }
         this.registerCapability('measure_luminance', 'SENSOR_MULTILEVEL', {
           getOpts: {
             getOnStart: false,
@@ -84,8 +88,10 @@ class MultiSensor_PD07Z extends ZwaveDevice {
         supported.includes('Relative humidity')
         || supported.includes('Humidity')
         || supported.includes(5);
-      if (hasHumidity && !this.hasCapability('measure_humidity')) {
-        await this.addCapability('measure_humidity');
+      if (hasHumidity) {
+        if (!this.hasCapability('measure_humidity')) {
+          await this.addCapability('measure_humidity');
+        }
         this.registerCapability('measure_humidity', 'SENSOR_MULTILEVEL', {
           getOpts: {
             getOnStart: false,


### PR DESCRIPTION
## Summary
- ensure multilevel sensor capabilities are always registered for NAS-PD01/02/03/07ZE
- add capability when missing before registration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac073f7f2c8330889ed50c558608c7